### PR TITLE
Updates to OpenPGP best practices

### DIFF
--- a/pages/security/message-security/openpgp/gpg-best-practices/en.text
+++ b/pages/security/message-security/openpgp/gpg-best-practices/en.text
@@ -2,7 +2,7 @@
 
 h2. How to use this guide.
 
-We have gathered here a lot of information about configuring OpenPGP. There are detailed explanations for each configuration suggestion. Many of these changes require you to make changes to the the gnupg configuration file on your machine located at @~/.gnupg/gpg.conf@. For your convenience, all the suggested changes to the gpg.conf file are gathered in one place [[near the bottom of this page ->/gpg-best-practices#putting-it-all-together]].
+We have gathered here a lot of information about configuring GnuPG. There are detailed explanations for each configuration suggestion. Many of these changes require you to make changes to the the GnuPG configuration file on your machine located at @~/.gnupg/gpg.conf@. For your convenience, all the suggested changes to the gpg.conf file are gathered in one place [[near the bottom of this page ->/gpg-best-practices#putting-it-all-together]].
 
 h2. Selecting a keyserver and configuring your machine to refresh your keyring.
 
@@ -10,7 +10,7 @@ If you do not regularly refresh your public keys, you do not get timely expirati
 
 h3. Use the sks keyserver pool, instead of one specific server, with secure connections.
 
-Most gpg clients come configured with a single, specific keyserver. This is not ideal because if the keyserver fails, or even worse, if it appears to work but is not functioning properly, you may not receive critical key updates.
+Most OpenPGP clients come configured with a single, specific keyserver. This is not ideal because if the keyserver fails, or even worse, if it appears to work but is not functioning properly, you may not receive critical key updates.
 
 Therefore, we recommend using the [[sks keyservers pool -> https://sks-keyservers.net/overview-of-pools.php]]. The machines in this pool have regular health checks to ensure that they are functioning properly. If a server is not working well, it will be removed automatically from the pool. 
 
@@ -69,7 +69,7 @@ pre. gpg --with-fingerprint --list-secret-key
 
 h2. Key configuration.
 
-Now that you are know how to receive regular key updates from a well-maintained keyserver, you should make sure that your gpg key is optimally configured. Many of these changes may require you to generate a new key.
+Now that you are know how to receive regular key updates from a well-maintained keyserver, you should make sure that your OpenPGP key is optimally configured. Many of these changes may require you to generate a new key.
 
 h3. Use a strong primary key
 


### PR DESCRIPTION
When translating into spanish i noticed some issues with the OpenPGP Best Practices document. This will remove a wrong link in the document, fix some incosistences as GnuPG is an implementation for OpenPGP and it also will fix some typos. 
