### PR TITLE
OpenPGP best practices: link to duraconf gpg.conf [EN, DE]

### DIFF
--- a/pages/security/message-security/openpgp/best-practices/de.text
+++ b/pages/security/message-security/openpgp/best-practices/de.text
@@ -223,29 +223,9 @@ gpg> save
 
 h2. Zusammenfassung aller Empfehlungen.
 
-Im Folgenden findest Du alle empfohlenen Einstellungen, die in dieser Anleitung diskutiert wurden in einem Textblock. Beachte, dass dies voraussetzt, dass Du den sks-Schlüsselserververbund mit hkps-Verbindung verwendest. Wenn Du nur hkp benutzt oder nicht den sks-Schlüsselserververbund verwenden möchtest, dann solltest Du die Zeilen, die sich auf den /Pfad/zum/Sicherheitszertifikat beziehen. Folgendes solltest Du in Deine @~/.gnupg/gpg.conf@ einfügen:
+Alle empfohlenen Einstellungen, die in dieser Anleitung diskutiert wurden, sind in einer Konfigurationsdatei in Jacob Appelbaum's [[duraconf -> https://github.com/ioerror/duraconf]] "Sammlung gehärteter Konfigurationsdateien" kombiniert. Lade [[gpg.conf -> https://raw.githubusercontent.com/ioerror/duraconf/master/configs/gnupg/gpg.conf]] und füge es in deine @~/.gnupg/gpg.conf@ ein.
 
-pre.. # sks-Schlüsselserver mit hkps verwenden
-keyserver hkps://hkps.pool.sks-keyservers.net
-keyserver-options ca-cert-file=/Pfad/zum/Sicherheitszertifikat/sks-keyservers.netCA.pem
-keyserver-options no-honor-keyserver-url
-# bei der Ausgabe von Zertifikaten die Benutzer-IDs getrennt vom Schlüssel anzeigen
-fixed-list-mode
-# kurze Schlüssel-IDs zu fälschen ist trivial; es ist einfach, eine Kollision langer Schlüssel-IDs zu erstellen; wenn Dir starke Identifizierungsmerkmale am Herzen liegen, solltest Du Dir immer den Fingerabdruck anzeigen lassen:
-keyid-format 0xlong
-with-fingerprint
-# Wenn alle Empfänger*innen mehrere Digest-Algorithmen unterstützen, sollte der stärkste gemeinsame ausgewählt werden:
-personal-digest-preferences SHA512 SHA384 SHA256 SHA224
-# Präferenzen für neue Schlüssel sollten stärkere Algorithmen vorziehen:
-default-preference-list SHA512 SHA384 SHA256 SHA224 AES256 AES192 AES CAST5 BZIP2 ZLIB ZIP Uncompressed
-# Wenn Du eine graphische Umgebung verwendest (und selbst, wenn Du das nicht tust), solltest Du einen Agent benutzen:
-# (aus ähnlichen Gründen wie in https://www.debian-administration.org/users/dkg/weblog/64)
-use-agent
-# Du solltest immer auf einen Blick erkennen, welche Benutzer-IDs gpg glaubt legitimerweise mit einem Schlüssel in Deinem Schlüsselbund in Verbindung bringen zu können:
-verify-options show-uid-validity
-list-options show-uid-validity
-# Bei OpenPGP-Zertifizierungen einen stärkeren Digest als SHA1 verwenden:
-cert-digest-algo SHA512
+Du solltest die folgenden Einstellungen einkommentieren und/oder an deine lokalen Präferenzen anpassen: @default-key@, @keyserver-options ca-cert-file@ und @keyserver-options http-proxy@.
 
 h2. Zusätzliche Vorschläge.
 

--- a/pages/security/message-security/openpgp/best-practices/en.text
+++ b/pages/security/message-security/openpgp/best-practices/en.text
@@ -229,31 +229,9 @@ gpg> save
 
 h2. Putting it all together.
 
-Below are all the recommended settings discussed on this guide combined into one. Note that this assumes you are using the sks keyserver pool via hkps transport. If you are using only hkp, or not using the sks keyserver pool, you should omit the lines relating to the /path/to/CA. The following should be included in your @~/.gnupg/gpg.conf@:
+All the recommended settings discussed on this guide have been combined into one configuration file at Jacob Appelbaum's [[duraconf -> https://github.com/ioerror/duraconf]] "collection of hardened configuration files". Download [[gpg.conf -> https://raw.githubusercontent.com/ioerror/duraconf/master/configs/gnupg/gpg.conf]] and include it in your @~/.gnupg/gpg.conf@.
 
-pre.. # use the sks keyserver via hkps
-keyserver hkps://hkps.pool.sks-keyservers.net
-keyserver-options ca-cert-file=/path/to/CA/sks-keyservers.netCA.pem
-keyserver-options no-honor-keyserver-url 
-# when outputting certificates, view user IDs distinctly from keys:
-fixed-list-mode
-# short-keyids are trivially spoofed; it's easy to create a long-keyid collision; if you care about strong key identifiers, you always want to see the fingerprint: 
-keyid-format 0xlong
-with-fingerprint
-# when multiple digests are supported by all recipients, choose the strongest one:
-personal-digest-preferences SHA512 SHA384 SHA256 SHA224
-# when multiple ciphers are supported by all recipients, choose the strongest one:
-personal-cipher-preferences AES256 AES192 AES CAST5
-# preferences chosen for new keys should prioritize stronger algorithms: 
-default-preference-list SHA512 SHA384 SHA256 SHA224 AES256 AES192 AES CAST5 BZIP2 ZLIB ZIP Uncompressed
-# If you use a graphical environment (and even if you don't) you should be using an agent:
-# (similar arguments as https://www.debian-administration.org/users/dkg/weblog/64)
-use-agent
-# You should always know at a glance which User IDs gpg thinks are legitimately bound to the keys in your keyring:
-verify-options show-uid-validity
-list-options show-uid-validity
-# when making an OpenPGP certification, use a stronger digest than the default SHA1:
-cert-digest-algo SHA512
+You should uncomment and/or adjust the following settings to your local preferences: @default-key@, @keyserver-options ca-cert-file@ and @keyserver-options http-proxy@.
 
 h2. Additional suggestions.
 


### PR DESCRIPTION
Replace the inline gpg.conf with a link to duraconf:configs/gnupg/gpg.conf
English and German
