### PR TITLE
Added FreeOTP as a replacement for Google Authenticator

### DIFF
--- a/pages/email/webmail/2factorauth/en.text
+++ b/pages/email/webmail/2factorauth/en.text
@@ -16,7 +16,7 @@ First, you will need to install a two-factor authentication application on the d
 * [[extension for firefox -> https://marketplace.firefox.com/app/gauth-authenticator/]]
 * [[symbian and webOS -> https://build.phonegap.com/apps/135419/]]
 
-Once you've installed the applicaiton, you'll need to login to roundcube and follow these steps:
+Once you've installed the application, you'll need to login to roundcube and follow these steps:
 
 # go to Settings --> 2-factor auth
 # click the activiate box, it will populate the secret box with a randomly generated secret


### PR DESCRIPTION
Since Google's Authenticator app is no longer being updated under a free license, I thought it might be more fitting to advocate the use of FreeOTP. FreeOTP is based off of the open source Authenticator app, and is still being maintained under an Apache license by Red Hat. It's available on F-Droid on Android, as well as Google and Apple's app stores.

This link (https://build.phonegap.com/apps/135419/) doesn't link to a symbian and iOS app, but a symbian and webOS app. I've updated the file to fix that small typo. 
