### PR TITLE
Fix broken link to GHCQ lawsuit PDF

### DIFF
--- a/pages/about-us/press/en.text
+++ b/pages/about-us/press/en.text
@@ -3,7 +3,7 @@
 
 h2. Statements
 
-[[2 July, 2014, Riseup joins six other organizations in lawsuit against British intelligence agency GCHQ -> press/14.07.02-gchq-pressrelease.pdf]]
+[[2 July, 2014, Riseup joins six other organizations in lawsuit against British intelligence agency GCHQ -> 14.07.02-gchq-pressrelease.pdf]]
 [[26 April, 2014, Riseup stands in solidarity with Saravá => sarava]]
 [[August 2013, Riseup and the recent email provider closures => recent-email-provider-closures]]
 [[April 2012, Server Seizure => fbi-seizes-anonymous-remailer]]


### PR DESCRIPTION
Currently is press/14.07.02-gchq-pressrelease.pdf, however it is being linked from the press folder already so it should be just be 14.07.02-gchq-pressrelease.pdf
