### PR TITLE
Empathy supports SSL/TLS and Proxyies

### DIFF
--- a/pages/chat/clients/en.text
+++ b/pages/chat/clients/en.text
@@ -16,7 +16,7 @@ h2. Recommended clients
 
 table(table table-striped).
 |_. Client |_. Supported OS |_. OTR? |_. Jingle? |_. Proxy? |_. SSL/TLS? |_. Tor? |_. Comments |
-| [[Empathy -> http://live.gnome.org/Empathy]] | GNU/Linux      | No           | *Yes* | ? | ? | ? | Open source. Stable and easy to use. |
+| [[Empathy -> http://live.gnome.org/Empathy]] | GNU/Linux      | No           | *Yes* | *Yes* (GNOME) | *Yes* (GNOME) | ? | Open source. Stable and easy to use. |
 | [[ChatSecure -> https://guardianproject.info/apps/chatsecure/]] | Android & iOS | *Yes* | No | *Yes* | *Yes* | *Yes* | Open source. Native Tor support. |
 | [[Pidgin]]   | Windows, GNU/Linux | *Yes*   | *Yes* (Linux) | *Yes* | *Yes* | *Yes* | Open source. Stable with many features. Use most current version. |
 | [[Adium]] | Mac | *Yes* | No | *Yes* | *Yes* | Partial | Open source. Good native build of Pidgin for Mac, but rarely updates libpurple. DNS and URL hovering information leaks.|


### PR DESCRIPTION
Support is provided through libsoup which can e.g. be configured in GNOME's control center. I don't knowh whether it works on other platforms (Epiphany on Windows?). I doubt Epiphany is safe to use via Tor so I left a ›?‹ there.
