### PR TITLE
Changed mentions of 'commercial' software to 'proprietary'

### DIFF
--- a/pages/email/clients/en.text
+++ b/pages/email/clients/en.text
@@ -9,7 +9,7 @@ A <b>mail client</b>, on the other hand, is a specialized application designed s
 For help configuring a particular client, click on one of the following links:
 
 table(table table-striped).
-|_.*Platform*|_.*Recommended Free Software Mail Clients*|_.*Other Commercial Clients*|
+|_.*Platform*|_.*Recommended Free Software Mail Clients*|_.*Proprietary Clients*|
 |Linux   | [[thunderbird]], [[evolution]], Kmail, Balsa, mutt, alpine, etc| |
 |Mac     | [[thunderbird]] | [[apple-mail]], [[postbox]] |
 |Windows | [[thunderbird]], [[evolution]]  | [[microsoft-outlook]], [[postbox]] |

--- a/pages/email/clients/microsoft-outlook/en.text
+++ b/pages/email/clients/microsoft-outlook/en.text
@@ -5,4 +5,6 @@ Microsoft Outlook is a personal information manager from Microsoft, available as
 
 Although often used mainly as an email application, it also includes a calendar, task manager, contact manager, note taking, journal, and web browsing.
 
+We don’t recommend it because it is not Free and Open Source Software (software libre).
+
 We have no tutorial written yet for configuring Outlook with Riseup. You can help by contributing one!

--- a/pages/email/clients/postbox/en.text
+++ b/pages/email/clients/postbox/en.text
@@ -1,5 +1,5 @@
 @title = 'Postbox'
 
-Postbox is a commercial mail client based on Thunderbird. It runs on Mac and Windows and has a much nicer interface than Thunderbird. You can download the application from http://postbox-inc.com
+Postbox is a proprietary mail client based on Thunderbird. It runs on Mac and Windows and has a much nicer interface than Thunderbird. You can download the application from http://postbox-inc.com
 
 We have no tutorial written yet for configuring Postbox with Riseup. You can help by contributing one!


### PR DESCRIPTION
At the risk of being a neckbeard, I've changed uses of "commercial" software to "proprietary" to clarify the difference between free/nonfree software. Free/libre/open source software can be developed by businesses, though that shouldn't stop us from dismantling capitalism :dog:. 
