### PR TITLE
swapped ghostery for disconnect

### DIFF
--- a/pages/security/network-security/better-web-browsing/en.text
+++ b/pages/security/network-security/better-web-browsing/en.text
@@ -42,7 +42,7 @@ Essential:
 
 Also recommended:
 
-* "Ghostery":https://www.ghostery.com: Track who is trying to track you and stop them.
+* "Disconnect":https://disconnect.me/: Track who is trying to track you and stop them.
 * "HTTPS Finder":https://code.google.com/p/https-finder/ Automatically tries to redirect Firefox to a HTTPS connection where available. This is especially good for sites HTTPS Everywhere has no rules for.
 
 Advanced:


### PR DESCRIPTION
Ghostery is not free software. It's not even completly open-source. Disconnect is GPL v3. 

Ghostery sells user data (they say it's anonymised) to ads compagnies to make money. It shows what kind of ads was blocked and by what for them to circumvent it. Disconnect does not.

Ghostery does not block anything but default. Disconnect does.

To me, the choice is clear.
