### PR TITLE
Translate `riseup-passwords` to German.

### DIFF
--- a/pages/security/human-security/riseup-password.de.text
+++ b/pages/security/human-security/riseup-password.de.text
@@ -1,0 +1,13 @@
+@title = "Riseup Passwörter"
+
+h2. Riseup Accounts
+
+Einige Riseup Dienste nutzen von einander getrennte und unabhängige Accounts (jeder mit einem eigenen Benutzernamen und einem eigenen Passwort).
+
+* *Primärer Riseup Account*: Diese Anmeldedaten werden für E-Mail, VPN und den Chat verwendet. Deine Einstellungen kannst du auf https://user.riseup.net ändern.
+* *Mailing Listen Account*: Wenn du dich für eine Mailing Liste auf https://lists.riseup.net registrierst, erhältst du einen Mailing Listen Account. Die Einstellungen für diesen Account kannst du auf https://lists.riseup.net bearbeiten.
+* *Gruppen Account*: Wenn du https://we.riseup.net nutzt, ist dieser Account unabhängig von deinem primären Riseup Account und deinem Mailing Listen Account. In der Zukunft werden wir die Gruppen Accounts und die Primären Accounts zusammenführen.
+
+h2. Wähle ein gutes Passwort
+
+<%= render 'common/good-passwords' %>


### PR DESCRIPTION
Another page translation, edited directly in Github and not tested with `amber rebuild`.
