### PR TITLE
Mention torbrowser-launcher script

### DIFF
--- a/pages/security/network-security/tor/de.text
+++ b/pages/security/network-security/tor/de.text
@@ -39,6 +39,8 @@ Lade die Installationsdatei für die jeweilige Architektur herunter und speicher
 (LANG ist die Sprache, die im Dateinamen angegeben ist)
 Um Tor zu starten einfach das Skript `start-tor-browser`im gerade extrahierten Ordner per Doppelklick oder Kommandozeile starten. Das wird Vidalia starten und sobald es mit Tor verbunden ist, wird es Firefox starten.
 
+Linux-Anwender könnten Sie auch interessieren: [[torbrowser-launcher => https://github.com/micahflee/torbrowser-launcher]]. Dieses Skript sorgt für Ihr Tor Browser Bundle ist auf dem neuesten Stand gehalten wird.
+
 *Entpacke TBB nicht als root.*
 
 

--- a/pages/security/network-security/tor/en.text
+++ b/pages/security/network-security/tor/en.text
@@ -35,6 +35,8 @@ Download the architecture-appropriate file above, save it somewhere. To extract 
 
 (where LANG is the language listed in the filename), and either double click on the directory or cd into it, then execute the start-tor-browser script. This will launch Vidalia and once that connects to Tor, it will launch Firefox. Do not unpack or run TBB as root.
 
+Linux users might also be interested in [[torbrowser-launcher => https://github.com/micahflee/torbrowser-launcher]]. This script ensures your Tor Browser Bundle is kept up to date. 
+
 h2. Using Tor
 
 Once extraction is complete, open the folder Tor Browser from the location you saved the bundle. Double click on the Start Tor Browser (4) application (it may be called Start Tor Browser.exe on some systems) The Vidalia window will shortly appear.


### PR DESCRIPTION
Added an update to en.text and de.text about Micah Lee's [torbrowser-launcher](https://github.com/micahflee/torbrowser-launcher) script for Linux users. 

My German is fairly bad (still learning!) so it's very likely that there are some gramatical errors in the blurb I put in de.text.
