### PR TITLE
Clarification on using subkey for encryption

### DIFF
--- a/pages/security/message-security/openpgp/gpg-best-practices/en.text
+++ b/pages/security/message-security/openpgp/gpg-best-practices/en.text
@@ -133,6 +133,8 @@ This will create a file called revoke.asc. You may wish to print a hardcopy of t
 
 h3. Only use your primary key for certification (and possibly signing). Have a separate subkey for encryption.
 
+Note this is the default behavior in the last versions of GPG, that is, a subkey is automatically created for encryption, and the primary key usage is "flagged" just for certification and signing.
+
 h3. (bonus) Have a separate subkey for signing, and keep your primary key entirely offline.
 
 In this scenario, your primary key is used only for certifications, which happen infrequently.

--- a/pages/security/message-security/openpgp/gpg-best-practices/en.text
+++ b/pages/security/message-security/openpgp/gpg-best-practices/en.text
@@ -85,7 +85,7 @@ h3. Use a strong primary key.
 
 Many people still have 1024-bit DSA keys. You really should transition to a stronger bit-length and hashing algo. This size is known now to be within Well Funded Organizations' ability to break. Also the hashing algo is showing its age.
 
-It is recommend to make a 4096bit RSA key, with the sha512 hashing algo, making a [[transition statement -> https://we.riseup.net/assets/176898/key%20transition]] that is signed by both keys, and then letting people know. Also have a look at this [[good document -> http://ekaia.org/blog/2009/05/10/creating-new-gpgkey]] that details *exactly* the steps that you need to create such a key, making sure that you are getting the right hashing algo (it can be slightly complicated if you are using GnuPG versions less than 1.4.10).
+It is recommend to make a 4096bit RSA key, with the sha512 hashing algo, making a [[transition statement -> https://we.riseup.net/assets/176898/key%20transition]] that is signed by both keys, and then letting people know. Also have a look at this [[good document -> http://ekaia.org/blog/2009/05/10/creating-new-gpgkey]] that details the steps that you need to create such a key, making sure that you are getting the right hashing algo (it can be slightly complicated if you are using GnuPG versions less than 1.4.10). Note the linked document creates an additional subkey for encryption (which is automatically created in last versions of GPG) and recommends some (slightly outdated) changes to the gpg.conf, while below in this guide you'll see additional recommendations concerning gpg.conf modifications.
 
 Transitioning can be painful, but it is worth it, and a good opportunity to practice with the tools!
 


### PR DESCRIPTION
Users may see the need of creating a new subkey, while this is already given.