### PR TITLE
Typo fix

### DIFF
--- a/pages/about-us/donate/en.text
+++ b/pages/about-us/donate/en.text
@@ -17,7 +17,7 @@ If you are a programmer, you can support Riseup by [[writing code => programmers
 h2. Suggested contribution
 
 * *Individuals:* We ask that individuals with email accounts or owners of lists give monthly or yearly. If you are broke, live in the global South, or live somewhere with a devalued currency, we don't expect you to give. This means that those with money in the global North should contribute extra as an act of solidarity. If you are unsure how much to contribute, might we suggest $5-$15 a month? If you can do more, please do!
-* *Groups:* We rely on organizations with email accounts or lists to contribute. It is especially essential for organizations with big mailing lists to contribute, as such lists are costly for us to provide. As a rough guideline, we ask that organizations annually contribute at least 1% of their annual budget--this is a $100 a year donation for an organization is an annual budget of $10,000.
+* *Groups:* We rely on organizations with email accounts or lists to contribute. It is especially essential for organizations with big mailing lists to contribute, as such lists are costly for us to provide. As a rough guideline, we ask that organizations annually contribute at least 1% of their annual budget--this is a $100 a year donation for an organization with an annual budget of $10,000.
 
 If you have a big list with over a hundred subscribers or with high traffic and lots of archives, increase the suggested donation amount several fold.
 


### PR DESCRIPTION
changed "is" to "with" in context of: "this is a $100 a year donation for an organization _with_ an annual budget of $10,000."