### PR TITLE
Remove Seattle Community Colocation Project links.

### DIFF
--- a/pages/about-us/projects/en.text
+++ b/pages/about-us/projects/en.text
@@ -22,7 +22,7 @@ In order to help other technology collectives get established, we provide free s
 
 h2. Seattle Community Colocation Project
 
-Riseup provides very affordable, secure, and reliable server co-location on a sliding scale basis, based on need. We host about 30 servers, including servers from social justice movement organizations in the US, UK, Germany, France, Italy, Mexico, Brazil, and Canada. See http://seaccp.org for more information.
+Riseup provides very affordable, secure, and reliable server co-location on a sliding scale basis, based on need. We host about 30 servers, including servers from social justice movement organizations in the US, UK, Germany, France, Italy, Mexico, Brazil, and Canada.
 
 h2. Supporting TOR
 

--- a/pages/about-us/projects/es.text
+++ b/pages/about-us/projects/es.text
@@ -22,7 +22,7 @@ Con el objetivo de ayudar a otros colectivos tecnológicos a establecerse, prove
 
 h2. Proyecto de Co-locación de la Comunidad Seattle
 
-Riseup provee co-locación asequible, segura, y confiable de acuerdo a ingresos y basado en necesidad. Hospedamos alrededor de 30 servidores, incluyendo servidores de organizaciones de movimientos de justicia social en EE.UU, el Reino Unido, Alemania, Francia, Italia, México, Brasil, y Canadá. Visita http://seaccp.org para mayor información.
+Riseup provee co-locación asequible, segura, y confiable de acuerdo a ingresos y basado en necesidad. Hospedamos alrededor de 30 servidores, incluyendo servidores de organizaciones de movimientos de justicia social en EE.UU, el Reino Unido, Alemania, Francia, Italia, México, Brasil, y Canadá.
 
 h2. Apoyando TOR
 

--- a/pages/about-us/projects/fr.text
+++ b/pages/about-us/projects/fr.text
@@ -22,7 +22,7 @@ Dans le but d'aider d'autres collectifs à s'établir, nous fournissons des serv
 
 h2. Projet de collocation communautaire à Seattle
 
-Riseup fourni des espace pour la colocation pour vos serveurs très abordable, sécurisé, et fiable celons vos besoins. Nous accueillons environs 30 serveurs, en incluant des serveurs pour les organisations du mouvement pour la justice social aux Etats-Unis, en Angleterre, Allemagne, France, Italie, Mexique, Brésil et au Canada. Pour plus d'informations nous vous invitons à aller vous renseigner ici http://seaccp.org/.
+Riseup fourni des espace pour la colocation pour vos serveurs très abordable, sécurisé, et fiable celons vos besoins. Nous accueillons environs 30 serveurs, en incluant des serveurs pour les organisations du mouvement pour la justice social aux Etats-Unis, en Angleterre, Allemagne, France, Italie, Mexique, Brésil et au Canada.
 
 h2. Aidez TOR
 


### PR DESCRIPTION
Remove the project link since the website is down.