### PR TITLE
Remove postbox mail client, since it isn't a FOSS.

### DIFF
--- a/amber/menu.txt
+++ b/amber/menu.txt
@@ -14,7 +14,6 @@ email
     apple-mail
     ios-mail
     microsoft-outlook
-    postbox
     sylpheed
     claws
     mutt

--- a/pages/email/clients/en.text
+++ b/pages/email/clients/en.text
@@ -11,8 +11,8 @@ For help configuring a particular client, click on one of the following links:
 table(table table-striped).
 |_.*Platform*|_.*Recommended Free Software Mail Clients*|_.*Proprietary Clients*|
 |Linux   | [[thunderbird]], [[evolution]], [[claws]], Kmail, Balsa, mutt, alpine, etc| |
-|Mac     | [[thunderbird]] | [[apple-mail]], [[postbox]] |
-|Windows | [[thunderbird]], [[evolution]]  | [[microsoft-outlook]], [[postbox]] |
+|Mac     | [[thunderbird]] | [[apple-mail]] |
+|Windows | [[thunderbird]], [[evolution]]  | [[microsoft-outlook]] |
 |Android | [[k9]] |  |
 |iOS     |  |  [[ios-mail]] |
 

--- a/pages/email/clients/es.text
+++ b/pages/email/clients/es.text
@@ -11,8 +11,8 @@ Para obtener ayuda sobre la configuración de algún cliente en concreto, pulsa 
 table(table table-striped).
 |_.*Plataforma*|_.*Clientes de software libre recomendados*|_.*Otros clientes comerciales*|
 |Linux   | [[thunderbird]], [[evolution]], Kmail, Balsa, mutt, alpine, etc| |
-|Mac     | [[thunderbird]] | [[apple-mail]], [[postbox]] |
-|Windows | [[thunderbird]], [[evolution]]  | [[microsoft-outlook]], [[postbox]] |
+|Mac     | [[thunderbird]] | [[apple-mail]] |
+|Windows | [[thunderbird]], [[evolution]]  | [[microsoft-outlook]] |
 |Android | [[k9]] |  |
 |iOS     |  |  [[ios-mail]] |
 

--- a/pages/email/clients/fr.text
+++ b/pages/email/clients/fr.text
@@ -11,8 +11,8 @@ Pour de l'aide sur comment configurer un client en particulier, cliquez sur un d
 table(table table-striped).
 |_.*Plate-forme*|_.*Clients courriel libres recommandés*|_.*Clients propriétaires*|
 |Linux   | [[thunderbird]], [[evolution]], [[claws]], Kmail, Balsa, mutt, alpine, etc| |
-|Mac     | [[thunderbird]] | [[apple-mail]], [[postbox]] |
-|Windows | [[thunderbird]], [[evolution]]  | [[microsoft-outlook]], [[postbox]] |
+|Mac     | [[thunderbird]] | [[apple-mail]] |
+|Windows | [[thunderbird]], [[evolution]]  | [[microsoft-outlook]] |
 |Android | [[k9]] |  |
 |iOS     |  |  [[ios-mail]] |
 

--- a/pages/email/clients/postbox/en.text
+++ b/pages/email/clients/postbox/en.text
@@ -1,5 +1,0 @@
-@title = 'Postbox'
-
-Postbox is a proprietary mail client based on Thunderbird. It runs on Mac and Windows and has a much nicer interface than Thunderbird. You can download the application from http://postbox-inc.com
-
-We have no tutorial written yet for configuring Postbox with Riseup. You can help by contributing one!

--- a/pages/email/clients/postbox/zh.text
+++ b/pages/email/clients/postbox/zh.text
@@ -1,5 +1,0 @@
-@title = 'Postbox'
-
-Postbox基于Thunderbird的商业邮件客户端。它运行在Mac和Windows，并具有比 Thunderbird更漂亮的界面。您可以从http://postbox-inc.com下载此应用。
-
-我们没有写 Postbox与 Riseup的配置教程。您可以通过贡献一个以提供帮助！

--- a/pages/email/clients/zh.text
+++ b/pages/email/clients/zh.text
@@ -11,8 +11,8 @@ h2.  邮件客户端是什么？
 table(table table-striped).
 |_.*平台*|_.*推荐的自由软件电子邮件客户端*|_.*其它商业客户端*|
 |Linux   | [[thunderbird]], [[evolution]], Kmail, Balsa, mutt, alpine, etc| |
-|Mac     | [[thunderbird]] | [[apple-mail]], [[postbox]] |
-|Windows | [[thunderbird]], [[evolution]]  | [[microsoft-outlook]], [[postbox]] |
+|Mac     | [[thunderbird]] | [[apple-mail]] |
+|Windows | [[thunderbird]], [[evolution]]  | [[microsoft-outlook]] |
 |Android | [[k9]] |  |
 |iOS     |  |  [[ios-mail]] |
 


### PR DESCRIPTION
I suggest to remove postbox mail client since it's not a FOSS. I can understand we have documentation for Apple Mail or Outlook since they are default email client for some OSs. We could also reconsider Outlook since it's not installed by default on Windows.