### PR TITLE
en gpg-keys: restore gpg output; link to Debian + Ubuntu (#336 #339)

### DIFF
--- a/pages/security/message-security/openpgp/gpg-keys/en.text
+++ b/pages/security/message-security/openpgp/gpg-keys/en.text
@@ -135,18 +135,18 @@ You can use this command to list your keys:
 
 This should output data in a format like this:
 
-bc. sec 4096R/0xE361D8GH916EFH89 2014-05-14 [expires: 2016-05-14]
-Key fingerprint = 1234 5678 90AB CDEF GH01  2344 5678 9012 ABCE FGH1
-uid John Q. Alias <the-email-youre-going-to-use@wherever.tld>
-ssb 4096R/0x40339E25E2F2D99E 2014-05-14
+bc. sec   4096R/0xE361D8GH916EFH89 2014-05-14 [expires: 2016-05-14]
+      Key fingerprint = 1234 5678 90AB CDEF GH01  2344 5678 9012 ABCE FGH1
+uid                            John Q. Alias <the-email-youre-going-to-use@wherever.tld>
+ssb   4096R/0x40339E25E2F2D99E 2014-05-14
 
 p. Any reference to your **KEY-ID** below can be found using the first command and looking at the output. The line you're looking at to find the **KEY-ID** is the **sec** line of each of the entries). The line contains sec, the key strength and type abbreviation (**4096R** in the first line), a slash, the **KEY-ID**, and then the creation date. The codebox below highlights the **KEY-ID**:
 
-bc. sec 4096R/0xE361D8GH916EFH89 2014-05-14 [expires: 2016-05-14]
-^KEY-ID^
-Key fingerprint = 1234 5678 90AB CDEF GH01  2344 5678 9012 ABCE FGH1
-uid John Q. Alias <the-email-youre-going-to-use@wherever.tld>
-ssb 4096R/0x40339E25E2F2D99E 2014-05-14
+bc. sec   4096R/0xE361D8GH916EFH89 2014-05-14 [expires: 2016-05-14]
+            ^KEY-ID^
+      Key fingerprint = 1234 5678 90AB CDEF GH01  2344 5678 9012 ABCE FGH1
+uid                            John Q. Alias <the-email-youre-going-to-use@wherever.tld>
+ssb   4096R/0x40339E25E2F2D99E 2014-05-14
 
 p. So for this example, the **KEY-ID** would be **E361D8GH916EFH89**.
 
@@ -178,7 +178,7 @@ It is **not recommended** to use Windows as a secure communication platform. Whi
 * User accounts are administrators by default
 * Since Windows is proprietary and closed-source, there is no outside scrutiny for defects, back doors, or anything that "phones home". You're trusting Microsoft completely with whatever secrets you choose to put on your computer.
 
-To ensure a secure communications platform, it's recommended to install linux. See [[Installing Ubuntu Linux -> /missing-page]] to create a secure communications platform or for additional information.
+To ensure a secure communications platform, it's recommended to install a "GNU":https://www.gnu.org "Linux":https://www.gnu.org/gnu/linux-and-gnu.html "free software":https://www.gnu.org/philosophy/free-system-distribution-guidelines.html "distribution":https://distrowatch.com, like *"Debian":https://www.debian.org/distrib (recommended)*, "Ubuntu":http://www.ubuntu.com/download/desktop ("beware privacy issues":https://www.gnu.org/philosophy/ubuntu-spyware.en.html) or a derivate.
 
 h2. Install Gpg4win
 
@@ -263,3 +263,5 @@ It is **not recommended** to use Mac OS X as a secure communication platform. Wh
 * Relies on a lot of proprietary software that can't be modified or scrutinized by you
 * The webcam can be remotely turned on, offered as a "feature" if the laptop gets stolen, which could be abused or exploited to violate your privacy
 * Filesystem not encrypted by default and the primary tool available "may have inadequate security":https://en.wikipedia.org/wiki/FileVault#Criticism.
+
+To ensure a secure communications platform, it's recommended to install a "GNU":https://www.gnu.org "Linux":https://www.gnu.org/gnu/linux-and-gnu.html "free software":https://www.gnu.org/philosophy/free-system-distribution-guidelines.html "distribution":https://distrowatch.com, like *"Debian":https://www.debian.org/distrib (recommended)*, "Ubuntu":http://www.ubuntu.com/download/desktop ("beware privacy issues":https://www.gnu.org/philosophy/ubuntu-spyware.en.html) or a derivate.


### PR DESCRIPTION
The original pgp output should be preserved as it trains readers to look for this layout.
Also the marker '^KEY-ID^' needs to be positioned at the correct place to make sense.

Debian and Ubuntu are preferred options to drive users away from windows.
They are responsive towards CVS and offer security patches when necessary.
Providing links to GNU and distrowatch for an informed decision.