### PR TITLE
Add opengrpah and twitter meta.

### DIFF
--- a/amber/layouts/default.html.haml
+++ b/amber/layouts/default.html.haml
@@ -1,14 +1,28 @@
 !!!
-%html{:lang => @locals[:locale].to_s}
+%html{:lang => @locals[:locale].to_s, :prefix => "og: http://ogp.me/ns/website"}
   %head
     %title
       = @page.nav_title + ' - ' + @site.title
+    %meta(name="description" content="Riseup provides online communication tools for people and groups working on liberatory social change. We are a project to create democratic alternatives and practice self-determination by controlling our own secure means of communications.")
     %meta(name="viewport" content="width=device-width, initial-scale=1.0")
     %meta(charset="UTF-8")
+
+    %meta{:property => "og:title", :content => @page.nav_title + ' - ' + @site.title}
+    %meta{:property => "og:type", :content => "website"}
+    %meta{:property => "og:url", :content => "https://riseup.net" + amber_path(@page)}
+    %meta{:property => "og:image", :content => "https://riseup.net/assets/images/riseup.net-inline.svg"}
+    %meta{:property => "og:description", :content => "Riseup provides online communication tools for people and groups working on liberatory social change. We are a project to create democratic alternatives and practice self-determination by controlling our own secure means of communications."}
+
+    %meta{:name => "twitter:card", :content => "summary_large_image"}
+    %meta{:name => "twitter:site", :content => "@riseupnet"}
+    %meta{:name => "twitter:title", :content => @page.nav_title + ' - ' + @site.title}
+    %meta{:name => "twitter:image", :content => "https://riseup.net/assets/images/riseup.net-inline.svg"}
+    %meta{:name => "twitter:description". :content => "Riseup provides online communication tools for people and groups working on liberatory social change. We are a project to create democratic alternatives and practice self-determination by controlling our own secure means of communications."}
+
     %link(rel="stylesheet" href="/assets/bootstrap.min.css")
-    -#%link(rel="stylesheet" href="/assets/font-awesome/css/font-awesome.min.css")
     %link(rel="stylesheet" href="/assets/style.css")
     %link(rel="icon" href="/assets/images/favicon.png" type="image/x-icon")
+
     = html_head_base
   %body
     #wrap

--- a/amber/layouts/home.html.haml
+++ b/amber/layouts/home.html.haml
@@ -3,8 +3,22 @@
   %head
     %title
       = @page.nav_title + ' - ' + @site.title
+    %meta(name="description" content="Riseup provides online communication tools for people and groups working on liberatory social change. We are a project to create democratic alternatives and practice self-determination by controlling our own secure means of communications.")
     %meta(name="viewport" content="width=device-width, initial-scale=1.0")
     %meta(charset="UTF-8")
+
+    %meta{:property => "og:title", :content => @page.nav_title + ' - ' + @site.title}
+    %meta{:property => "og:type", :content => "website"}
+    %meta{:property => "og:url", :content => "https://riseup.net" + amber_path(@page)}
+    %meta{:property => "og:image", :content => "https://riseup.net/assets/images/riseup.net-inline.svg"}
+    %meta{:property => "og:description", :content => "Riseup provides online communication tools for people and groups working on liberatory social change. We are a project to create democratic alternatives and practice self-determination by controlling our own secure means of communications."}
+
+    %meta{:name => "twitter:card", :content => "summary_large_image"}
+    %meta{:name => "twitter:site", :content => "@riseupnet"}
+    %meta{:name => "twitter:title", :content => @page.nav_title + ' - ' + @site.title}
+    %meta{:name => "twitter:image", :content => "https://riseup.net/assets/images/riseup.net-inline.svg"}
+    %meta{:name => "twitter:description". :content => "Riseup provides online communication tools for people and groups working on liberatory social change. We are a project to create democratic alternatives and practice self-determination by controlling our own secure means of communications."}
+
     %link(rel="stylesheet" href="/assets/bootstrap.min.css")
     %link(rel="stylesheet" href="/assets/font-awesome-4.6.3/css/font-awesome.min.css")
     %link(rel="stylesheet" href="/assets/style.css")

--- a/pages/assets/images/riseup.net-inline.svg
+++ b/pages/assets/images/riseup.net-inline.svg
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://web.resource.org/cc/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="689"
+   height="174.61"
+   id="svg1418"
+   sodipodi:version="0.32"
+   inkscape:version="0.44"
+   sodipodi:docbase="/home/dev/img/sources"
+   sodipodi:docname="riseup.net-a.svg"
+   version="1.0"
+   inkscape:export-filename="/home/dev/img/sources/riseup.net-a.png"
+   inkscape:export-xdpi="78.079361"
+   inkscape:export-ydpi="78.079361">
+  <defs
+     id="defs1420" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="276.13312"
+     inkscape:cy="81.193125"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:window-width="1050"
+     inkscape:window-height="812"
+     inkscape:window-x="61"
+     inkscape:window-y="30"
+     width="689px"
+     height="174.61px" />
+  <metadata
+     id="metadata1423">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(93.95417,-152.4797)">
+    <g
+       inkscape:export-ydpi="72.000000"
+       inkscape:export-xdpi="72.000000"
+       inkscape:export-filename="/home/elijah/img/riseup/rainbow.png"
+       transform="matrix(1.9228,0,0,1.9228,-543.2423,-667.3182)"
+       style="fill:black;fill-opacity:1;stroke:none;stroke-width:0.99300146;stroke-miterlimit:4;stroke-opacity:1"
+       id="g1812">
+      <path
+         id="path1813"
+         d="M 319.71511,490.07402 L 317.66117,469.62194 L 317.30128,454.76097 L 324.07747,454.04119 L 324.79726,459.79945 L 329.47585,455.12086 L 339.19291,453.68129 L 343.15172,455.12086 L 342.43194,462.87132 L 337.39345,461.79165 L 333.32924,462.36236 L 329.66858,466.38291 L 327.00027,469.87642 L 327.97453,483.19242 L 328.43984,490.64473 L 319.71511,490.07402 z "
+         style="fill-rule:evenodd;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;display:block" />
+      <path
+         id="path1814"
+         d="M 346.18408,468.0211 L 343.9125,490.08622 L 353.90747,490.08622 L 353.90747,475.53779 L 353.90747,468.26358 L 346.18408,468.0211 z "
+         style="fill-rule:evenodd;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;display:block" />
+      <path
+         id="path1815"
+         d="M 380.92111,465.19783 L 383.80024,458.71978 L 378.40187,456.56043 L 372.6436,454.76097 L 363.6463,458.35989 L 358.96771,465.91761 L 360.40728,473.47534 L 369.40457,476.35447 L 377.32219,479.95339 L 376.76956,484.01761 L 372.74901,486.08963 L 364.36609,485.71166 L 360.40728,482.11274 L 356.80836,487.87101 L 361.48695,492.18971 L 375.88262,493.62928 L 383.44035,492.18971 L 384.52002,484.63198 L 385.23981,474.91491 L 376.24252,470.23631 L 369.76446,468.79675 L 369.40457,464.47805 L 373.72327,461.9588 L 380.92111,465.19783 z "
+         style="fill-rule:evenodd;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;display:block" />
+      <path
+         id="path1816"
+         d="M 395.69591,472.03577 L 405.41299,471.67588 L 416.56963,471.31599 L 416.20974,461.9588 L 410.45147,457.28021 L 397.13548,455.48075 L 389.21786,459.79945 L 387.4184,469.51653 L 387.4184,480.31328 L 393.17667,487.51112 L 406.85256,492.18971 L 415.48996,492.18971 L 418.72898,488.2309 L 414.77018,482.47263 L 411.17126,484.99187 L 400.7344,483.55231 L 396.77559,481.03307 L 394.61624,476.35447 L 395.69591,472.03577 z "
+         style="fill-rule:evenodd;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;display:block" />
+      <path
+         id="path1817"
+         d="M 420.16855,459.43956 L 419.80866,472.75556 L 421.60811,482.83252 L 426.6466,489.67047 L 430.60541,491.82982 L 440.32248,491.82982 L 447.52032,487.15122 L 449.31978,476.71436 L 449.67967,463.03848 L 449.67967,456.56043 L 442.48183,456.20054 L 442.48183,464.83794 L 441.76205,476.71436 L 439.6027,484.99187 L 435.284,486.07155 L 430.24552,483.55231 L 428.08617,477.79404 L 427.41005,465.96128 L 427.66453,458.40355 L 420.16855,459.43956 z "
+         style="fill-rule:evenodd;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;display:block" />
+      <path
+         id="path1818"
+         d="M 455.07804,456.56043 L 454.71815,474.19512 L 453.8493,489.80145 L 454.55099,491.82982 L 461.55609,491.17927 L 462.21413,472.37009 L 473.02896,471.39582 L 476.43514,467.88423 L 477.45307,460.20301 L 474.1523,455.12086 L 461.91598,453.68129 L 455.07804,456.56043 z "
+         style="fill-rule:evenodd;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;display:block" />
+      <path
+         id="path1819"
+         d="M 491.91049,490.39025 L 490.83081,474.55501 L 490.83081,458.35989 L 498.38854,458.35989 L 498.38854,464.83794 L 504.14681,459.07967 L 514.22378,457.28021 L 521.06172,462.67859 L 520.70183,475.99458 L 521.42161,490.39025 L 513.1441,489.67047 L 513.50399,475.63469 L 511.70453,467.71707 L 507.38583,468.79675 L 502.34735,470.23631 L 498.38854,475.2748 L 498.38854,483.9122 L 498.38854,490.39025 L 491.91049,490.39025 z "
+         style="fill-rule:evenodd;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;display:block" />
+      <path
+         id="path1820"
+         d="M 537.40592,475.33654 L 548.92246,474.61676 L 555.7604,473.53709 L 554.68073,463.46012 L 540.28506,455.90239 L 531.64766,460.94088 L 527.32895,469.21839 L 524.80971,480.73492 L 530.20809,491.17178 L 538.84549,492.97124 L 548.92246,492.61135 L 555.04062,488.29265 L 550.00213,481.8146 L 548.20267,483.97395 L 538.84549,486.1333 L 533.08722,480.37503 L 533.80701,477.136 L 537.40592,475.33654 z "
+         style="fill-rule:evenodd;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;display:block" />
+      <path
+         id="path1821"
+         d="M 559.50839,456.51676 L 566.13552,456.26228 L 565.92469,448.64281 L 573.12253,449.72248 L 573.88598,456.41136 L 581.61086,456.15687 L 581.61086,463.5911 L 573.37701,463.44203 L 573.48242,469.51653 L 573.48242,477.07426 L 573.48242,482.83252 L 574.96565,485.98422 L 580.61851,485.51143 L 581.67261,491.40818 L 583.1995,497.22819 L 571.99919,492.79659 L 566.28458,487.75811 L 564.84502,481.59628 L 564.80135,474.55501 L 565.41573,463.23121 L 559.44664,463.03848 L 559.50839,456.51676 z "
+         style="fill-rule:evenodd;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;display:block" />
+      <path
+         id="path1822"
+         d="M 354.97232,465.97776 L 347.9304,465.42978 L 347.22574,458.03038 C 347.22574,458.03038 343.7216,451.07336 341.56262,450.00519 C 339.40312,448.93535 336.88352,446.79678 336.88352,446.79678 C 336.88352,446.79678 339.76268,444.30142 342.28228,446.08374 C 344.80187,447.86662 344.80187,448.22287 344.80187,448.22287 C 344.80187,448.22287 347.68051,449.29271 348.40121,443.94462 C 349.12138,438.59764 351.22139,430.79309 351.22139,430.79309 C 351.22139,430.79309 352.66071,428.65397 353.74098,430.08005 C 354.82073,431.50613 351.63943,443.58893 351.63943,443.58893 L 357.92754,430.20454 C 357.92754,430.20454 359.72747,428.42222 360.08756,430.56134 C 360.44661,432.70046 355.59937,443.94406 355.59937,443.94406 L 361.7985,434.66841 C 361.7985,434.66841 364.31809,433.24289 364.31809,435.38145 C 364.31809,437.52002 358.47854,445.0139 358.47854,445.0139 L 366.12527,440.46222 C 366.12527,440.46222 368.64434,439.74918 368.28477,441.88775 C 367.9252,444.02632 360.76376,445.82031 358.83863,450.36032 C 356.91401,454.90145 354.97232,465.97776 354.97232,465.97776 z "
+         style="stroke:none;display:block" />
+      <path
+         id="path1823"
+         d="M 477.34026,482.96852 L 476.35566,490.29889 L 483.57603,489.63249 L 482.26324,482.96852 L 477.34026,482.96852 z "
+         style="fill-rule:evenodd;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;display:block" />
+    </g>
+    <g
+       id="g3535"
+       transform="matrix(2.149895,1.731362e-2,-1.731362e-2,2.149895,-123.1838,111.2582)"
+       style="display:block"
+       inkscape:export-filename="/home/elijah/dev/img/sources/star.png"
+       inkscape:export-xdpi="78.356918"
+       inkscape:export-ydpi="78.356918">
+      <path
+         sodipodi:type="star"
+         style="fill:black;fill-opacity:1;stroke:none;stroke-width:8.125;stroke-miterlimit:4;stroke-opacity:1"
+         id="path3536"
+         sodipodi:sides="5"
+         sodipodi:cx="23.752853"
+         sodipodi:cy="-127.36288"
+         sodipodi:r1="53.263973"
+         sodipodi:r2="21.30559"
+         sodipodi:arg1="1.5707963"
+         sodipodi:arg2="2.1991149"
+         inkscape:flatsided="false"
+         inkscape:rounded="0"
+         inkscape:randomized="0"
+         d="M 23.752855,-74.098904 L 11.229741,-110.12629 L -26.904195,-110.9034 L 3.4900338,-133.94667 L -7.5549257,-170.45434 L 23.752854,-148.66847 L 55.06063,-170.45434 L 44.015674,-133.94667 L 74.409903,-110.90341 L 36.275964,-110.12629 L 23.752855,-74.098904 z "
+         transform="matrix(0.668803,0.110086,-0.110086,0.668803,24.08755,136.5205)" />
+      <path
+         style="fill:red;fill-opacity:1;fill-rule:evenodd;stroke:black;stroke-width:0.25pt;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 55.880603,41.770983 L 76.68637,32.05701 L 66.103541,51.993921 L 81.968742,68.833387 L 59.294277,64.910749 L 38.892065,24.273482 L 55.880603,41.770983 z "
+         id="path3537"
+         sodipodi:nodetypes="ccccccc" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
I add meta tag for opengraph and twitter cards. I don't know if it's something that the birds can find usefull. The riseup pages will have a better reference on facebook and twitter with those tags.

It'll be possible to check if twitter cards are correct [here](https://cards-dev.twitter.com/validator) and the rendering on facebook [here](https://developers.facebook.com/tools/debug/) since I can't check it by myself, because the page need to be online.
