### PR TITLE
Fix link in advanced extensions for Firefox

### DIFF
--- a/pages/security/network-security/better-web-browsing/en.text
+++ b/pages/security/network-security/better-web-browsing/en.text
@@ -99,7 +99,7 @@ For Firefox:
 
 * [[Self Destructing Cookies (Firefox) => https://addons.mozilla.org/en-US/firefox/addon/self-destructing-cookies/]] will clean out the cookies for a website when all the tabs for that site have been closed (rather than requiring that you restart the browser).
 * [[µMatrix => https://addons.mozilla.org/en-US/firefox/addon/umatrix/]] allows you to selectively block Javascript, plugins or other resources and control third-party resources. It also features extensive privacy features like user-agent masquerading, referering blocking and so on. It effectively replaces NoScript and RequestPolicy.
-* [[User-Agent Switcher => https://chrome.google.com/webstore/detail/user-agent-switcher/ffhkkpnppgnfaobgihpdblnhmmbodake]] will allow you to modify the HTTP User-Agent.
+* [[User-Agent Switcher => https://addons.mozilla.org/en-US/firefox/addon/user-agent-switcher/]] will allow you to modify the HTTP User-Agent.
 * [[Canvas Fingerprint Blocker => https://addons.mozilla.org/en-US/firefox/addon/canvasblocker/]] will allow you to disable HTML5 canvas support for particular websites.
 
 For Chrome:


### PR DESCRIPTION
The link for User-Agent Switcher for Firefox currently leads to the Chrome extension, not the Firefox one. This should fix it.