### PR TITLE
Resolving the canary mistery

### DIFF
--- a/pages/about-us/canary/de.text
+++ b/pages/about-us/canary/de.text
@@ -26,9 +26,10 @@ Um riseup's Schlüssel herunter zu laden und die verwendete Schlüsselbezeichnun
 <code>gpg --verify canary-statement-signed.txt</code>
 # Die Ausgabe sollte so aussehen:
 
-pre..
+<pre>
 gpg: Signature made Mon 15 Aug 2016 10:01:19 PM PDT
 gpg:           using RSA key 0x3043E2B7139A768E
 gpg: Good signature from "Riseup Networks <collective@riseup.net>"
+</pre>
 
 p. Stelle sicher, dass es die Aussage "Good signature" enthält und bestätige, dass die Schlüsselbezeichnung mit der [[vorher verifizierten => network-security/certificates#complete-verification]] übereinstimmt. Wenn der Text verändert wurde, ist die Information in der Erklärung nicht vertrauenswürdig.

--- a/pages/about-us/canary/en.text
+++ b/pages/about-us/canary/en.text
@@ -26,9 +26,10 @@ You should follow [[these instructions to download riseup's gpg key and verify t
 <code>gpg --verify canary-statement-signed.txt</code>
 # You should get output that says:
 
-pre..
+<pre>
 gpg: Signature made Mon 15 Aug 2016 10:01:19 PM PDT
 gpg:                using RSA key 0x3043E2B7139A768E
 gpg: Good signature from "Riseup Networks <collective@riseup.net>"
+</pre>
 
 p. You should make sure that it says "Good signature" in the output and confirm that the keyid matches the one you verified [[here earlier. => network-security/certificates#complete-verification]] If this text has been altered, then this information should not be trusted.

--- a/pages/about-us/canary/ru.text
+++ b/pages/about-us/canary/ru.text
@@ -26,9 +26,10 @@ h2. Инструкции по проверке
 <code>gpg --verify canary-statement-signed.txt</code>
 # Вы должны получить следующий вывод:
 
-pre..
+<pre>
 gpg: Signature made Fri 02 Oct 2015 09:54:28 AM PDT
 gpg:                using RSA key 0x3043E2B7139A768E
 gpg: Good signature from "Riseup Networks <collective@riseup.net>"
+</pre>
 
 p. Убедитесь, что вывод содержит "Good signature", а также, что идентификатор ключа совпадает с тем, который вы проверили [[ранее. => network-security/certificates#complete-verification]] Если текст вывода отличается, то этой информации не следует доверять.


### PR DESCRIPTION
It seems that someone managed to [start a FUD at reddit](https://www.reddit.com/r/WhereIsAssange/comments/5dm8vy/disparity_in_the_riseup_canary_gpg_rsa_key_was/) over the GPG signature of the canary page not being rendered properly.

This started to get out of control when someone [registered this as a fact](https://en.wikipedia.org/w/index.php?title=Riseup&diff=prev&oldid=750238770) at the [riseup's wikipedia page](https://en.wikipedia.org/wiki/Riseup).

And now as a result of the three month lifespan of the canary, people are associating facts with inventions and this could probably get worse.