### PR TITLE
Corrected misspelling

### DIFF
--- a/amber/locales/de.yml
+++ b/amber/locales/de.yml
@@ -5,7 +5,7 @@ de:
   missing_translation: "Diese Seite ist noch nicht ins Deutsche übersetzt worden."
   support_riseup: "Unterstütze Riseup!"
   motto: "Komm raus aus dem Internet, wir sehen uns auf den Straßen."
-  footer_tagline: "Diese Seite wird betrieben von riseup.net, deinem freundlichen autonomen Technikkollektik seit 1999."
+  footer_tagline: "Diese Seite wird betrieben von riseup.net, deinem freundlichen autonomen Technikkollektiv seit 1999."
   contribute_to_help: "Fühle dich eingeladen, Inhalt und Übersetzungen zu dieser Seite beizusteuern."
   system_updates: "Systemmeldungen"
   # quick links:


### PR DESCRIPTION
The German word for "collective" is „Kollektiv“ so the correct translation for "tech collective" should be „Technikkollektiv“.