### PR TITLE
Rewrite the contact page

### DIFF
--- a/pages/about-us/contact/en.text
+++ b/pages/about-us/contact/en.text
@@ -1,6 +1,10 @@
 @title = 'Contact'
 
+h2. Help Tickets
+
 The best way to get in touch with us is to fill out a help ticket. Please visit https://user.riseup.net to create a ticket. Note that you do not need to have an email account with riseup to file a help ticket.
+
+h2. Email
 
 To contact us regarding general questions about our collective, send mail to collective@riseup.net. Any help questions directed to this email will be ignored.
 
@@ -12,6 +16,8 @@ There is no particular reason you should trust this key. You can see who trusts 
 
 pre. gpg --list-sigs 0x4E0791268F7C67EABE88F1B03043E2B7139A768E
 
+h2. Mail
+
 Our mailing address is:
 
 <pre>
@@ -20,9 +26,20 @@ PO Box 4282
 Seattle, WA 98194 USA
 </pre>
 
-Riseup collective members and friends are often found on irc.indymedia.org in the #riseup chat room.  *Please note: In order to join the #riseup channel, you have to be connected via SSL on port 6697.* You can use the web interface at https://chat.indymedia.org to contact us there if "irc" is not a familiar acronym.
+h2. IRC
 
-Find us on "diaspora":https://diasp.org/people/e6901810cb670133bdbb782bcb452bd5 (riseup@diasp.org)
-We are also on "twitter":https://twitter.com/riseupnet.
+<pre>
+server : irc.indymedia.org
+port for SSL connection : 6697
+channel : #riseup
+web interface : https://chat.indymedia.org
+</pre>
 
-Looking for high resolution Riseup graphics? Check out [[images]].
+h2. Social Networks
+
+* Diaspora : "riseup@diasp.org":https://diasp.org/people/e6901810cb670133bdbb782bcb452bd5
+* Twitter : "@riseupnet":https://twitter.com/riseupnet
+
+h2. Riseup graphics
+
+Check out the [[images => images]] page.

--- a/pages/about-us/contact/fr.text
+++ b/pages/about-us/contact/fr.text
@@ -1,6 +1,10 @@
 @title = 'Contact'
 
+h2. Billets de dépannage
+
 La meilleure façon de nous contacter est de remplir un billet de dépannage. Vous pouvez aller sur https://user.riseup.net pour créer un billet. Notez que vous n'avez pas besoin d'un compte courriel avec riseup pour créer un billet de dépannage.
+
+h2. Courriel
 
 Si vous avez des questions générales sur notre collectif, vous pouvez nous envoyer un courriel à collective@riseup.net. Toute demande d'aide à cette adresse sera ignorée.
 
@@ -12,6 +16,8 @@ Vous n'avez pas de raison particulière d'avoir confiance dans cette clé. Vous 
 
 pre. gpg --list-sigs 3043E2B7139A768E
 
+h2. Courrier
+
 Notre adresse postale est la suivante:
 
 <pre>
@@ -20,9 +26,20 @@ PO Box 4282
 Seattle, WA 98194 USA
 </pre>
 
-Les membres du collectif Riseup et leurs ami-e-s sont souvent sur irc.indymedia.org sur le canal #riseup. *Remarque : Pour vous connecter au canal #riseup, vous devez vous connecter en utilisant SSL sur le port 6697.* Si IRC n'est pas un acronyme qui vous est familier, vous pouvez utiliser l'interface web à https://chat.indymedia.org pour nous rejoindre.
+h2. IRC
 
-Retrouvez-nous sur "diaspora":https://diasp.org/people/e6901810cb670133bdbb782bcb452bd5 (riseup@diasp.org)
-Et sur "twitter":https://twitter.com/riseupnet.
+<pre>
+serveur : irc.indymedia.org
+port : 6697
+channel : #riseup
+interface web : https://chat.indymedia.org
+</pre>
 
-Vous cherchez des images en haute résolution du collectif Riseup? Elles sont disponibles [[ici -> images]].
+h2. Médias sociaux
+
+* Diaspora : "riseup@diasp.org":https://diasp.org/people/e6901810cb670133bdbb782bcb452bd5
+* Twitter : "@riseupnet":https://twitter.com/riseupnet
+
+h2. Infographie de Riseup
+
+Voir la page [[images => images]].


### PR DESCRIPTION
I rewrite the contact page. The page is know split in section splited using subtitle and the IRC information are display in a pre like the mailling address other information we could have to paste in a terminal like I suggested in #394