### PR TITLE
Note hopenpgp-tools broken with GnuPG >= 2.1

### DIFF
--- a/pages/security/message-security/openpgp/gpg-best-practices/en.text
+++ b/pages/security/message-security/openpgp/gpg-best-practices/en.text
@@ -221,6 +221,8 @@ There is a handy tool that will perform the key checks below for you. You can ge
 
 bc. sudo apt-get install hopenpgp-tools
 
+Note: @hopenpgp-tools@ currently does not work with GnuPG version 2.1 and up. This is because GnuPG version 2.1 and up store both your public and private key in @~/.gnupg/pubring.kbx@. @hkt@ expects to find your public key in @~/.gnupg/pubring.gpg@ and will give an error message if you are using GnuPG version 2.1 and up.
+
 To run these tests with the tool, you can do the following:
 
 bc. hkt export-pubkeys '<fingerprint>' | hokey lint


### PR DESCRIPTION
`hkt` in the `hopenpgp-tools` package tries to open `~/.gnupg/pubring.gpg`.

See, for example, [line 162 of `hkt.hs`](https://anonscm.debian.org/cgit/users/clint/hopenpgp-tools.git/tree/hkt.hs#n162).

GnuPG version 2.1 and up store keys in `~/.gnupg/pubring.kbx` in the [_keybox_ format](https://www.gnupg.org/faq/whats-new-in-2.1.html#keybox).

For that reason, when a user runs `hkt export-pubkeys` they will be presented with the following message:

`hkt: /home/user/.gnupg/pubring.gpg: openBinaryFile: does not exist
(No such file or directory)`