### PR TITLE
fix script-security and auth contradiction

### DIFF
--- a/pages/vpn/vpn-red/en.text
+++ b/pages/vpn/vpn-red/en.text
@@ -57,8 +57,12 @@ proto udp
 # proto tcp
 
 auth-user-pass
+# needs to call prompt scripts
+script-security 1
+
 # alternately:
 # auth-user-pass ~/vpn/auth.txt
+# script-security 0
 
 <ca>
 -----BEGIN CERTIFICATE-----
@@ -106,7 +110,6 @@ persist-tun
 persist-key
 resolv-retry infinite
 remote-cert-tls server
-script-security 0
 # enable only if your system supports TLS 1.2
 # tls-version-min 1.2
 </pre>

--- a/pages/vpn/vpn-red/riseup.ovpn
+++ b/pages/vpn/vpn-red/riseup.ovpn
@@ -18,8 +18,12 @@ proto udp
 # proto tcp
 
 auth-user-pass
+# needs to call prompt scripts
+script-security 1
+
 # alternately:
 # auth-user-pass ~/vpn/auth.txt
+# script-security 0
 
 <ca>
 -----BEGIN CERTIFICATE-----
@@ -67,6 +71,5 @@ persist-tun
 persist-key
 resolv-retry infinite
 remote-cert-tls server
-script-security 0
 # enable only if your system supports TLS 1.2
 # tls-version-min 1.2


### PR DESCRIPTION
Out of the box on Debian stable "stretch", openvpn fails with the suggested configuration:

```
$ openvpn Downloads/riseup.ovpn
Wed Aug  9 19:31:06 2017 OpenVPN 2.4.0 x86_64-pc-linux-gnu [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [PKCS11] [MH/PKTINFO] [AEAD] built on Jun 22 2017
Wed Aug  9 19:31:06 2017 library versions: OpenSSL 1.0.2l  25 May 2017, LZO 2.08
Wed Aug  9 19:31:06 2017 WARNING: External program may not be called unless '--script-security 2' or higher is enabled. See --help text or man page for detailed info.
Wed Aug  9 19:31:06 2017 ERROR: Failed retrieving username or password
Wed Aug  9 19:31:06 2017 Exiting due to fatal error
```

This is because `script-security 0` completely disables external scripts. It *seems* that this also breaks password prompting, which is ridiculous, but there you got it: bumping it back to `1` fixes the error for me.