### PR TITLE
Recommend RSA 3072-bit

### DIFF
--- a/pages/security/message-security/openpgp/gpg-best-practices/en.text
+++ b/pages/security/message-security/openpgp/gpg-best-practices/en.text
@@ -111,7 +111,7 @@ h3. Use a strong primary key.
 
 Some people still have 1024-bit DSA keys. You really should transition to a stronger bit-length and hashing algo. In 2011, the US government instution NIST has [[deprecated -> http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf]] DSA-1024, since 2013 it is even [[disallowed -> http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf]].
 
-It is recommend to make a 4096bit RSA key, with the sha512 hashing algo, making a [[transition statement -> key-transition]] that is signed by both keys, and then letting people know. Also have a look at this [[good document -> http://ekaia.org/blog/2009/05/10/creating-new-gpgkey]] that details *exactly* the steps that you need to create such a key, making sure that you are getting the right hashing algo (it can be slightly complicated if you are using GnuPG versions less than 1.4.10).
+It is recommend to make a 3072-bit RSA key, with the sha512 hashing algo, making a [[transition statement -> key-transition]] that is signed by both keys, and then letting people know. Also have a look at this [[good document -> http://ekaia.org/blog/2009/05/10/creating-new-gpgkey]] that details *exactly* the steps that you need to create such a key, making sure that you are getting the right hashing algo (it can be slightly complicated if you are using GnuPG versions less than 1.4.10).
 
 Transitioning can be painful, but it is worth it, and a good opportunity to practice with the tools!
 
@@ -243,13 +243,15 @@ To determine if your key is a V3 key you can do the following:
 
 bc. gpg --export-options export-minimal --export '<fingerprint>' | gpg --list-packets |grep version
 
-h4. primary keys should be DSA-2 or RSA (RSA preferred), ideally 4096 bits or more.
+h4. primary keys should be RSA, ideally 3072 bits.
 
-To check if you are using DSA-2 or RSA, you can do this:
+To check if you are using RSA, you can do this:
 
 bc. gpg --export-options export-minimal --export '<fingerprint>' | gpg --list-packets | grep -A2 '^:public key packet:$' | grep algo
 
-If the reported algorithm is 1, you are using RSA. If it is 17, then it is DSA and you will need to confirm that the size reported in the next check reports a bit-length key size greater than 1024, otherwise you aren't using DSA-2.
+If the reported algorithm is 1, you are using RSA.
+
+ If it is 17, then it is DSA and you will need to confirm that the size reported in the next check reports a bit-length key size greater than 1024, otherwise you aren't using DSA-2.
 
 If the reported algorithm is 19, you are using ECDSA, if it is 18 you are using ECC, and the key bit-length determination check below is not an appropriate criteria for these types of keys as as the key sizes will drop significantly.
 

--- a/pages/security/message-security/openpgp/gpg-keys/en.text
+++ b/pages/security/message-security/openpgp/gpg-keys/en.text
@@ -23,7 +23,7 @@ h3. Create and export an OpenPGP Public/Private Key pair
 # Enter your email and the name you would like to be associated with the key. This doesn't need to be your real name.
 # Select advanced options.
 # Encryption type should be RSA.
-# Key strength should be 4096.
+# Key strength should be 3072.
 # Expiration date should be within less then two years. *You can always extend the key expiration as long as you still have access to the key, even after it has expired.* [[Why should I set an expiration --> gpg-best-practices#use-an-expiration-date-less-than-two-years]].
 # Enter a **strong** password that you can remember. **If you forget this password, it cannot be recovered and any encrypted data you have using it for, including emails, will be permanently inaccessible.**
 # The computer will now generate the key, which may take some time. After this, you will have an OpenPGP key pair that is ready to be used--Great! You can manage the key options, export the public key, change the password, delete and/or revoke the key, and perform other key adjustments through the Seahorse user interface or the command line.
@@ -100,7 +100,7 @@ bc. Please select what kind of key you want:
 
 Select the type of key you want. **RSA and RSA** is the recommended type. **(sign only)** keys cannot be used for encryption.
 
-Next, enter the key size you want. **4096** is recommended.
+Next, enter the key size you want. **3072** is recommended.
 
 bc. What keysize do you want? (2048)
 


### PR DESCRIPTION
This removes the recommendation for DSA(2) and recommends key-strength 3072-bit over 4096-bit. See #455.