### PR TITLE
Add link to Geary page

### DIFF
--- a/pages/email/clients/en.text
+++ b/pages/email/clients/en.text
@@ -10,7 +10,7 @@ For help configuring a particular client, click on one of the following links:
 
 table(table table-striped).
 |_.*Platform*|_.*Recommended Free Software Mail Clients*|_.*Proprietary Clients*|
-|Linux   | [[thunderbird]], [[evolution]], [[claws]], Kmail, Balsa, [[mutt]], alpine, [[sylpheed]] | |
+|Linux   | [[thunderbird]], [[evolution]], [[claws]], Kmail, Balsa, [[mutt]], alpine, [[sylpheed]], [[geary]] | |
 |Mac     | [[thunderbird]], [[sylpheed]] | [[apple-mail]] |
 |Windows | [[thunderbird]], [[evolution]], [[sylpheed]], [[claws]]  | [[microsoft-outlook]] |
 |Android | [[k9]] |  |


### PR DESCRIPTION
A page for Geary already exists, so this just adds a link to it in the list of Linux email clients.