### PR TITLE
Rename BCash to Bitcoin Cash

### DIFF
--- a/amber/locales/de.yml
+++ b/amber/locales/de.yml
@@ -72,9 +72,9 @@ de:
   faircoin: "FairCoin"
   faircoin_description: "FairCoin wird von einer Nonprofit-Organisation betrieben und verbraucht weniger Energie als andere Kryptowährungen."
 
-  bcash: "BCash"
-  bcash_description: "BCash ist eine Abspaltung (hard fork) von Bitcoin und wird auch Bitcoin Cash genannt. BCash und Bitcoin sind zwei verschiedene Währungen! Bitcoins, die an eine BCash-Adresse übertragen werden, sind unwiederbringlich verloren."
-
+  bitcoincash: "Bitcoin Cash"
+  bitcoincash_description: "Bitcoin Cash ist eine Abspaltung (hard fork) von Bitcoin. Bitcoin Cash und Bitcoin sind zwei verschiedene Währungen! Bitcoins, die an eine Bitcoin Cash-Adresse übertragen werden, sind unwiederbringlich verloren."
+  
   paypal: "Paypal"
   paypal_note: "Funktioniert in vielen Ländern der Welt"
   paypal_description: "Paypal akzeptiert Kreditkarten und unterstützt Daueraufträge (für Daueraufträge ist ein Paypal-Konto nötig)."

--- a/amber/locales/en.yml
+++ b/amber/locales/en.yml
@@ -73,10 +73,10 @@ en:
   faircoin: "FairCoin"
   faircoin_description: "FairCoin is run by a non-profit network of radical activists, propagates the non-speculative values of the solidarity economy, and uses less electricity than other cryptocurrencies."
 
-  bcash: "BCash"
-  bcash_description: |
-    BCash a hard fork of Bitcoin and is sometimes called Bitcoin Cash.
-    BCash is not Bitcoin. If you send Bitcoin to a BCash address, the money will be lost forever.
+  bitcoincash: "Bitcoin Cash"
+  bitcoincash_description: |
+    Bitcoin Cash a hard fork of Bitcoin and is sometimes called Bitcoin Cash.
+    Bitcoin Cash is not Bitcoin. If you send Bitcoin to a Bitcoin Cash address, the money will be lost forever.
 
   paypal: "Paypal"
   paypal_note: "Works from many countries."

--- a/amber/locales/fr.yml
+++ b/amber/locales/fr.yml
@@ -73,10 +73,10 @@ fr:
   faircoin: "FairCoin"
   faircoin_description: "FairCoin est gérée par une organisation à but non lucratif et utilise moins d'électricité que les autres crypto-monnaies."
 
-  bcash: "BCash"
-  bcash_description: |
-    BCash est une fourche complète de Bitcoin et est parfois appelée Bitcoin Cash.
-    BCash n'est pas Bitcoin. Si vous envoyez des Bitcoins à une address BCash, l'argent sera à jamais perdu.
+  bitcoincash: "Bitcoin Cash"
+  bitcoincash_description: |
+    Bitcoin Cash est une fourche complète de Bitcoin.
+    Bitcoin Cash n'est pas Bitcoin. Si vous envoyez des Bitcoins à une address Bitcoin Cash, l'argent sera à jamais perdu.
 
   paypal: "Paypal"
   paypal_note: "Fonctionne dans plusieurs pays différents."

--- a/pages/about-us/donate/inc/_cryptocurrency_forms.haml
+++ b/pages/about-us/donate/inc/_cryptocurrency_forms.haml
@@ -79,13 +79,13 @@
         %input(type="submit" value="#{t :generate}")
 
 .panel.panel-default
-  %h2.hidey= t :bcash
+  %h2.hidey= t :bitcoincash
   .panel-heading
-    %strong#bcash
+    %strong#bitcoincash
       <img src="img/bitcoin-cash.png">
-      BCash (BCH)
+      Bitcoin Cash (BCH)
   .panel-body
-    %p= t :bcash_description
+    %p= t :bitcoincash_description
     .donation
       %form(action="/new-address/bch" method="post")
         %b= t :grab_address


### PR DESCRIPTION
This is a request to have Bitcoin Cash properly named on your site. Its been many months since PR #507 was denied being merged and  was hoping that you might have a change of heart and reconsider your stance on the name. 