### PR TITLE
fix links on claws email client page

### DIFF
--- a/pages/email/clients/claws/de.text
+++ b/pages/email/clients/claws/de.text
@@ -4,7 +4,7 @@ h2. Was ist Claws?
 
 p(pull-right). !(image-right)it_bites.png!
 
-Claws Mail war das vorinstallierte Emailprogramm von "Tails - The Amnesiac Incognito Live System":https://tails.boum.org. Seit Tails 1.8 wird es durch [[Thunderbird]] ersetzt ("Anleitung zum Migrieren deiner Mails":https://tails.boum.org/doc/anonymous_internet/claws_mail_to_icedove/index.de.html). Es ist Freie Software und für viele Unix-artige Plattformen und Windows verfügbar. Du kannst es auf der "Webseite von Claws Mail":http://www.claws-mail.org/downloads.php?section=downloads herunterladen.
+Claws Mail war das vorinstallierte Emailprogramm von "Tails - The Amnesiac Incognito Live System":https://tails.boum.org. Seit Tails 1.8 wird es durch [[Thunderbird]] ersetzt ("Anleitung zum Migrieren deiner Mails":https://tails.boum.org/news/version_2.0/index.de.html#index2h2). Es ist Freie Software und für viele Unix-artige Plattformen und Windows verfügbar. Du kannst es auf der "Webseite von Claws Mail":http://www.claws-mail.org/downloads.php?section=downloads herunterladen.
 
 Claws Mail versucht, funktionsreich, schnell und stabil zu sein. Es unterstützt IMAP und POP, farbige Etiketten, Rechtschreibprüfung, Filter und Unterstützung für [[OpenPGP-Verschlüsselung->openpgp]]
 

--- a/pages/email/clients/claws/de.text
+++ b/pages/email/clients/claws/de.text
@@ -4,7 +4,7 @@ h2. Was ist Claws?
 
 p(pull-right). !(image-right)it_bites.png!
 
-Claws Mail war das vorinstallierte Emailprogramm von "Tails - The Amnesiac Incognito Live System":https://tails.boum.org. Seit Tails 1.8 wird es durch [[Thunderbird]] ersetzt ("Anleitung zum Migrieren deiner Mails":https://tails.boum.org/news/version_2.0/index.de.html#index2h2). Es ist Freie Software und für viele Unix-artige Plattformen und Windows verfügbar. Du kannst es auf der "Webseite von Claws Mail":http://www.claws-mail.org/downloads.php?section=downloads herunterladen.
+Claws Mail war das vorinstallierte Emailprogramm von "Tails - The Amnesiac Incognito Live System":https://tails.boum.org. Seit Tails 1.8 wird es durch [[Thunderbird]] ersetzt ("Anleitung zum Migrieren deiner Mails":https://web.archive.org/web/20161005203605/https://tails.boum.org/doc/anonymous_internet/claws_mail_to_icedove/index.de.html). Es ist Freie Software und für viele Unix-artige Plattformen und Windows verfügbar. Du kannst es auf der "Webseite von Claws Mail":http://www.claws-mail.org/downloads.php?section=downloads herunterladen.
 
 Claws Mail versucht, funktionsreich, schnell und stabil zu sein. Es unterstützt IMAP und POP, farbige Etiketten, Rechtschreibprüfung, Filter und Unterstützung für [[OpenPGP-Verschlüsselung->openpgp]]
 

--- a/pages/email/clients/claws/en.text
+++ b/pages/email/clients/claws/en.text
@@ -4,7 +4,7 @@ h2. What is Claws?
 
 p(pull-right). !(image-right)it_bites.png!
 
-Claws Mail was the default mail client bundled with "Tails - The Amnesiac Incognito Live System":https://tails.boum.org. Since Tails 1.8 it has been replaced with [[thunderbird]] ("Migrating from Claws Mail to Icedove":https://tails.boum.org/news/version_2.0/index.en.html#index2h2). It is Free Software and is available for a variety of Unix-type platforms, and Windows. You can download Claws Mail "from the Claws Mail website":http://www.claws-mail.org/downloads.php?section=downloads.
+Claws Mail was the default mail client bundled with "Tails - The Amnesiac Incognito Live System":https://tails.boum.org. Since Tails 1.8 it has been replaced with [[thunderbird]] ("Migrating from Claws Mail to Icedove":https://web.archive.org/web/20151217135432/https://tails.boum.org/doc/anonymous_internet/claws_mail_to_icedove/index.en.html). It is Free Software and is available for a variety of Unix-type platforms, and Windows. You can download Claws Mail "from the Claws Mail website":http://www.claws-mail.org/downloads.php?section=downloads.
 
 Claws Mail aims to be feature rich, fast, and stable.  It has IMAP and POP support, multiple account support, colored labels, spell checking, filtering, and support for [[OpenPGP encryption->openpgp]].
 

--- a/pages/email/clients/claws/en.text
+++ b/pages/email/clients/claws/en.text
@@ -4,7 +4,7 @@ h2. What is Claws?
 
 p(pull-right). !(image-right)it_bites.png!
 
-Claws Mail was the default mail client bundled with "Tails - The Amnesiac Incognito Live System":https://tails.boum.org. Since Tails 1.8 it has been replaced with [[thunderbird]] ("Migrating from Claws Mail to Icedove":https://tails.boum.org/doc/anonymous_internet/claws_mail_to_icedove/index.en.html). It is Free Software and is available for a variety of Unix-type platforms, and Windows. You can download Claws Mail "from the Claws Mail website":http://www.claws-mail.org/downloads.php?section=downloads.
+Claws Mail was the default mail client bundled with "Tails - The Amnesiac Incognito Live System":https://tails.boum.org. Since Tails 1.8 it has been replaced with [[thunderbird]] ("Migrating from Claws Mail to Icedove":https://tails.boum.org/news/version_2.0/index.en.html#index2h2). It is Free Software and is available for a variety of Unix-type platforms, and Windows. You can download Claws Mail "from the Claws Mail website":http://www.claws-mail.org/downloads.php?section=downloads.
 
 Claws Mail aims to be feature rich, fast, and stable.  It has IMAP and POP support, multiple account support, colored labels, spell checking, filtering, and support for [[OpenPGP encryption->openpgp]].
 


### PR DESCRIPTION
https://riseup.net/en/email/clients/claws & the de version of this page has a 404 link.

Original: https://support.riseup.net/en/topics/10649-404-links-on-claws-mail-page/posts

This part: (Migrating from Claws Mail to Icedove) takes to this link: https://tails.boum.org/doc/anonymous_internet/claws_mail_to_icedove/index.en.html which gives 404.

That doc was probably deleted, I didn't find it on archive.org nor google cache instead that should be replaced by https://tails.boum.org/news/version_2.0/index.en.html#index2h2 which announces about migrating to thunderbird.