### PR TITLE
added from of confirm email

### DIFF
--- a/pages/email/settings/aliases/en.text
+++ b/pages/email/settings/aliases/en.text
@@ -35,7 +35,7 @@ If your alias is on riseup.net and is available (meaning no one has the alias or
 If your alias is external, you will need to confirm you have access to the email. In addition to the "changes saved" message is also a message that a confirmation email has been sent. Additionally, the alias appears in your list with a "Confirmation Pending" tag. To finish the process:
 
 # Click on the link in the email
-# Upon loading the page, you will get a confirmation 
+# Upon loading the page, you will get a confirmation from no-reply@riseup.net
 # Click the "Continue" button
 # Your alias list will be display with the alias having a "Send" tag
 


### PR DESCRIPTION
Added the email address that the confirmation email is coming from for aliases to reduce the likelihood of confirmation emails ending up in spam folders.