### PR TITLE
riseup-vpn doesn't leave the firewall either the pid file after a kill

### DIFF
--- a/pages/vpn/linux/de.md
+++ b/pages/vpn/linux/de.md
@@ -60,11 +60,7 @@ Falls irgendwas nicht mehr funktioniert, führ diese Befehle aus:
 
 ```
 sudo pkill -e -f riseup-vpn
-sudo /snap/bin/riseup-vpn.bitmask-root firewall stop
-test -f ~/.config/leap/systray.pid && rm -v ~/.config/leap/systray.pid
 ```
-
-Mit diesen Befehlen werden alle RiseupVPN-Prozesse beendet und die PID-Datei geleert.
 
 ### RiseupVPN startet nicht
 

--- a/pages/vpn/linux/en.md
+++ b/pages/vpn/linux/en.md
@@ -72,11 +72,7 @@ If anything stops working, run these commands and then try again:
 
 ```
 sudo pkill -e -f riseup-vpn
-sudo /snap/bin/riseup-vpn.bitmask-root firewall stop
-test -f ~/.config/leap/systray.pid && rm -v ~/.config/leap/systray.pid
 ```
-
-These commands will ensure that all RiseupVPN processes are killed, the egress firewall rules are removed, and the PID file is cleaned up.
 
 ### Won't start
 

--- a/pages/vpn/linux/fr.md
+++ b/pages/vpn/linux/fr.md
@@ -62,11 +62,7 @@ Si quelque chose arrête de fonctionner, exécutez ces commandes et essayez de n
 
 ```
 sudo pkill -e -f riseup-vpn
-sudo /snap/bin/riseup-vpn.bitmask-root firewall stop
-test -f ~/.config/leap/systray.pid && rm -v ~/.config/leap/systray.pid
 ```
-
-Ces commandes s'assurent que tous les processus RiseupVPN sont fermés, que les sorties de pare-feu sont supprimées et le que fichier PID est nettoyé.
 
 ### Le VPN ne démarre pas
 

--- a/pages/vpn/linux/it.md
+++ b/pages/vpn/linux/it.md
@@ -62,11 +62,7 @@ Se qualcosa smette di funzionare, lancia questo comando e prova di nuovo:
 
 ```
 sudo pkill -e -f riseup-vpn
-sudo /snap/bin/riseup-vpn.bitmask-root firewall stop
-test -f ~/.config/leap/systray.pid && rm -v ~/.config/leap/systray.pid
 ```
-
-Questi comandi assicurano che tutti i processi di RiseupVPN vengano killati, le regole di uscita del firewall vengano rimosse e che il PID file venga ripulito.
 
 ### Problemi all'avvio
 

--- a/pages/vpn/linux/pt.md
+++ b/pages/vpn/linux/pt.md
@@ -30,11 +30,10 @@ sudo snap install --classic riseup-vpn
 
 ### Encerramento forçado
 
-Se a RiseupVPN travar ou sua conexão de rede estiver bloqueada, você pode forçar o encerramento do programa e desabilitar o firewall com os seguintes comandos:
+Se a RiseupVPN travar ou sua conexão de rede estiver bloqueada, você pode forçar o encerramento do programa:
 
 ```
 sudo pkill -e -f riseup-vpn
-sudo /snap/bin/riseup-vpn.bitmask-root firewall stop
 ```
 
 ### Não inicializa


### PR DESCRIPTION
Remove the documentation about turning off the firewall and removing the
PID file. Since more than a year riseup-vpn does handle signals and do
the cleaning properly.

Also this instructions are confusing if you are using the debian package
instead of the snap, as the location of bitmask-root is a different one.