### PR TITLE
fix tbird use_status_for_biff_setting

### DIFF
--- a/pages/email/clients/thunderbird/en.text
+++ b/pages/email/clients/thunderbird/en.text
@@ -73,7 +73,7 @@ Luckily there is a fix: Thunderbird has some hidden options, that a does a compl
 
 To set this, go to the menu *Edit > Preferences > Advanced > General > Config Editor*
 
-* set @use_status_for_biff@ to *false*
+* set @mail.imap.use_status_for_biff@ to *false*
 * set @mail.server.default.autosync_offline_stores@ to *true*
 
 h3. Consider automatically deleting old email


### PR DESCRIPTION
We offer this as a way to reduce overhead/server load, but it seems to
be the wrong setting. Everywhere I look including [MozillaZine][1] shows
the setting being prepended with `mail.imap`, which indeed exists as a
default setting and is consistent with the hierarchical formatting of
the other settings.

[1]: http://kb.mozillazine.org/Mail_and_news_settings