### PR TITLE
Update debian buster install instructions

### DIFF
--- a/pages/vpn/linux/en.md
+++ b/pages/vpn/linux/en.md
@@ -5,14 +5,14 @@
 
 To use Riseup's VPN service, you will need to install the program called RiseupVPN. On Linux, it is available either as a `snap`, or as a package in Debian Stable.
 
-RiseupVPN is currently tested on the **Ubuntu LTS** and **Debian Stable**. If you have a different release, it may or may not work.
+RiseupVPN is currently tested on **Ubuntu LTS** (18.04) and **Debian Stable**. If you have a different release, it may or may not work.
 
 ## Snap Installation
 
 If you use Ubuntu, snap is already installed. Otherwise, run:
 
 ```
-sudo apt install snapd
+sudo apt install snapd gnome-software-plugin-snap
 ```
 
 Then, simply search for **RiseupVPN** in the **Software Center** or click on this link:
@@ -30,6 +30,8 @@ sudo snap install --classic riseup-vpn
 If you get an error stating that "python" is missing from /usr/bin/env, you need to install python. This is the case for instance in Lubuntu, at least since version 19.04.
 
 ## Package Installation
+
+This is the recommended way to install on Debian Stable.
 
        echo "deb http://deb.leap.se/client release buster" | sudo tee -a /etc/apt/sources.list.d/leap.list
        curl https://deb.leap.se/apt.key | sudo apt-key add -


### PR DESCRIPTION
* ubuntu lts: there are several concurrent ones that are still 'supported' (https://wiki.ubuntu.com/Releases) specifying it's latest LTS
* debian buster uses by default gnome, which needs an extra package to deal with snaps from within the software center
https://0xacab.org/leap/bitmask-vpn/issues/20#note_293529 for some background.