### PR TITLE
[Improve] Enforce https URL

### DIFF
--- a/pages/vpn/linux/en.md
+++ b/pages/vpn/linux/en.md
@@ -34,7 +34,7 @@ If you get an error stating that "python" is missing from /usr/bin/env, you need
 Run the following commands in a terminal to install the Debian Stable package.
 
        sudo apt install leap-archive-keyring
-       echo "deb http://deb.leap.se/client release buster" | sudo tee -a /etc/apt/sources.list.d/leap.list
+       echo "deb https://deb.leap.se/client release buster" | sudo tee -a /etc/apt/sources.list.d/leap.list
        sudo apt update
        sudo apt install riseup-vpn
 

--- a/pages/vpn/linux/fr.md
+++ b/pages/vpn/linux/fr.md
@@ -35,7 +35,7 @@ Si jamais un message d'erreur apparaît indiquant que "python" n'est pas install
 Exécutez les commandes suivantes dans un terminal pour installer RiseupVPN avec le paquet pour Debian Stable.
 
        sudo apt install leap-archive-keyring
-       echo "deb http://deb.leap.se/client release buster" | sudo tee -a /etc/apt/sources.list.d/leap.list
+       echo "deb https://deb.leap.se/client release buster" | sudo tee -a /etc/apt/sources.list.d/leap.list
        sudo apt update
        sudo apt install riseup-vpn
 


### PR DESCRIPTION
Since deb.leap.se domain has support for TLS/SSL, it's a good idea to
prefer https URL over http.