### PR TITLE
Complete GPG output

### DIFF
--- a/pages/about-us/canary/en.md
+++ b/pages/about-us/canary/en.md
@@ -42,4 +42,13 @@ You should follow [[these instructions to download riseup's gpg key and verify t
 	Primary key fingerprint: 4E07 9126 8F7C 67EA BE88  F1B0 3043 E2B7 139A 768E
 	```
 
-You should make sure that it says "Good signature" in the output and confirm that the keyid matches the one you verified [[here earlier. => network-security/certificates#complete-verification]] If this text has been altered, then this information should not be trusted.
+You should make sure that it says "Good signature" in the output and confirm that the keyid matches the one you verified [[here earlier => network-security/certificates#complete-verification]]. If this text has been altered, then this information should not be trusted.
+
+Unless you have taken explicit steps to build a trust path to the Riseup Collective key, you will see a warning message similar to:
+
+	```
+	gpg: WARNING: This key is not certified with a trusted signature!
+	gpg:          There is no indication that the signature belongs to the owner.
+	```
+
+However, you still should see the “Good signature”.

--- a/pages/about-us/canary/en.md
+++ b/pages/about-us/canary/en.md
@@ -34,7 +34,11 @@ You should follow [[these instructions to download riseup's gpg key and verify t
 	```
 	gpg: Signature made Mon 27 Jul 2020 03:57:58 PM PDT
 	gpg:                using RSA key 4E0791268F7C67EABE88F1B03043E2B7139A768E
-	gpg: Good signature from "Riseup Networks <collective@riseup.net>"
+	gpg:                issuer "collective@riseup.net"
+	gpg: Good signature from "Riseup Treasurer <treasurer@riseup.net>" [unknown]
+	gpg:                 aka "Riseup Networks <collective@riseup.net>" [unknown]
+	gpg: WARNING: This key is not certified with a trusted signature!
+	gpg:          There is no indication that the signature belongs to the owner.
 	Primary key fingerprint: 4E07 9126 8F7C 67EA BE88  F1B0 3043 E2B7 139A 768E
 	```
 


### PR DESCRIPTION
I changed the shown GPG output to the correct (complete) output. This is specially important because of the following lines (that are omitted right now):
```
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
```
A person not familiar with GPG may get freaked out from this message, as if there's something wrong. Adding this on the output shown on the canary page avoids this, as everyone will know that's the expected output.