### PR TITLE
radical-servers: Disroot no longer provides Matrix

### DIFF
--- a/pages/security/resources/radical-servers/de.text
+++ b/pages/security/resources/radical-servers/de.text
@@ -147,7 +147,7 @@ h2. Disroot
 * Dateispeicher (4GB NextCloud, Lufi)
 * Soziale Netzwerke (Diaspora)
 * Forum (Discourse)
-* Direktnachrichten (XMPP, Matrix)
+* Direktnachrichten (XMPP)
 * Pad (Etherpad)
 * Pastebin (PrivateBin)
 * Suchmaschine (Searx)

--- a/pages/security/resources/radical-servers/en.text
+++ b/pages/security/resources/radical-servers/en.text
@@ -153,7 +153,7 @@ Currently the following services are provided:
  * File hosting (4GB NextCloud, Lufi)
  * Social networking (Diaspora)
  * Forum (Discourse)
- * Messaging (XMPP, Matrix)
+ * Messaging (XMPP)
  * Pad (Etherpad)
  * Pastebin (PrivateBin)
  * Search engine (Searx)


### PR DESCRIPTION
Server was [shut down](https://disroot.org/en/blog/matrix-closure) in 2018.