### PR TITLE
Add liberapay directly to the sponsor section

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 custom: https://riseup.net/donate
+liberapay: Riseup


### PR DESCRIPTION
Since we're on github and a lot of projects here use liberapay, I add the riseup liberapay account directly, so people with an account will be able to simply click on the link on the right column.