### PR TITLE
VPN page: Fix tense and remove ambiguity about Bitmask

### DIFF
--- a/pages/vpn/en.haml
+++ b/pages/vpn/en.haml
@@ -73,7 +73,7 @@ All VPNs share [[some limitations => limitations]], please familiarize yourself 
 
 %h2 What about Bitmask/Riseup Black?
 
-The Bitmask-based VPN (which we were calling "Riseup Black") is no longer supported and has been replaced by RiseupVPN. It had all the features that made Bitmask special, in fact under the hood RiseupVPN is using the Bitmask code, but it has better multiplatform support, no more users and passwords to increase your anonymity and an even simplier user experience.
+The Bitmask-based VPN (which we were calling "Riseup Black") is no longer supported and has been replaced by RiseupVPN. RiseupVPN has all the features that made Bitmask special, in fact under the hood RiseupVPN is using the Bitmask code, but it has better multiplatform support, no more users and passwords to increase your anonymity and an even simplier user experience.
 
 %p
 If you still have Bitmask installed, please remove it before installing RiseupVPN.


### PR DESCRIPTION
The wording "it had" left one to wonder what thing *had* features that made Bitmask great and why that would be relevant now.  Presumably, this was intended to say that RiseupVPN, the replacement for Riseup Black, which was based on Bitmask, *has* all of the features that made Bitmask great.