### PR TITLE
Fix mixed http/https content alert

### DIFF
--- a/amber/layouts/default.html.haml
+++ b/amber/layouts/default.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html{:lang => @locals[:locale].to_s, :prefix => "og: http://ogp.me/ns/website"}
+%html{:lang => @locals[:locale].to_s, :prefix => "og: https://ogp.me/ns/website"}
   %head
     %title
       = @page.nav_title + ' - ' + @site.title


### PR DESCRIPTION
Not 100% sure if there was a valid reason for this not to be HTTPS, but it gave me a mixed http/https alert of https://riseup.net/vpn in Firefox 88.0.1.