### PR TITLE
update The Digital First Aid Kit URL in Security resources EN,PT

### DIFF
--- a/pages/security/resources/en.text
+++ b/pages/security/resources/en.text
@@ -12,7 +12,7 @@ h4. Security guides for beginners
 * *[[Security Planner => https://securityplanner.org]]* from [[Citizen Lab => https://citizenlab.ca]] (Creative Commons: Attribution)
 * *[[Surveillance Self-defense => https://ssd.eff.org]]* from [[Electronic Frontier Foundation => https://eff.org]] (Creative Commons: Attribution)
 * *[[Security In-a-box => https://securityinabox.org]]* from [[Tactical Technology Collective => https://tacticaltech.org/]] (Creative Commons: Attribution-ShareAlike)
-* *[[Digital First Aid => https://www.digitaldefenders.org/digitalfirstaid/]]* from [[Digital Defenders Partnership => https://www.digitaldefenders.org]] 
+* *[[Digital First Aid => https://digitalfirstaid.org]]* from [[Digital Defenders Partnership => https://www.digitaldefenders.org]] 
 
 h4. Security guides for organizations
 

--- a/pages/security/resources/pt.text
+++ b/pages/security/resources/pt.text
@@ -12,7 +12,7 @@ h4. Guias para iniciantes
 * *[[Security Planner => https://securityplanner.org]]*, do [[Citizen Lab => https://citizenlab.ca]] (Creative Commons: Atribuição).
 * *[[Autodefesa contra Vigilância => https://ssd.eff.org/pt-br]]*, da [[Electronic Frontier Foundation => https://eff.org]] (Creative Commons: Atribuição).
 * *[[Security in-a-Box - Ferramentas de Segurança Digital => https://securityinabox.org]]*, do [[Tactical Technology Collective => https://securityinabox.org/pt/]] (Creative Commons: Atribuição-CompartilhaIgual).
-* *[[Digital First Aid => https://www.digitaldefenders.org/digitalfirstaid/]]*, da [[Digital Defenders Partnership => https://www.digitaldefenders.org]].
+* *[[Digital First Aid => https://digitalfirstaid.org/pt/]]*, da [[Digital Defenders Partnership => https://www.digitaldefenders.org]].
 
 h4. Guias para organizações
 


### PR DESCRIPTION
Hello,
- The URL: https://www.digitaldefenders.org/digitalfirstaid/
is no longer valid. The new guide URL is:
https://digitalfirstaid.org
- Replaced the URL in Security resources for EN and PT (other translations aren't currently supported)

