### PR TITLE
add job posting

### DIFF
--- a/pages/about-us/labor/en.md
+++ b/pages/about-us/labor/en.md
@@ -1,0 +1,48 @@
+@title = 'Labor'
+@this.alias = '/labor'
+@toc = false
+
+## Riseup Networks is seeking a Systems Administrator
+
+Riseup Networks, a 501\(c)(4) non-profit organization provides online communication tools for people and groups working on liberatory social change. We create democratic alternatives and practice self-determination by controlling our own secure means of communications - https://riseup.net/en/about-us
+
+### Summary
+This role requires several years of experience running open source systems. It requires 20 hours a week, minimum. This position will focus on debugging, triaging and fixing issues related to our communication service infrastructure.
+
+The ideal candidate is committed to F/OSS, has strong troubleshooting skills, is able to diagnose problems quickly, is creative and resourceful and is able to communicate well in an online, remote-work scenario. This job requires a broad range of skills, and ability to apply those skills to new and different challenges each day.
+
+This is a part-time, fully remote position, and labor is paid at the same rate as all other Riseup workers.
+
+### Responsibilities
+
+* Build up documentation on services and how to resolve issues
+* Administrate infrastructure, including firewalls, databases, DNS, email
+* Troubleshoot and respond to issues and outages
+* Monitor performance and trends and maintain systems accordingly
+* Upgrade, and maintain in a highly reliable manner, systems with new releases
+
+### Required Skills
+
+* Experience as a Systems Administrator
+* Experience with databases, networking, git, DNS, logging, prometheus, email, backups
+* Configuration management: puppet and ansible
+* Knowledge of system security, and ability to work in a confidential environment
+* Strong skills in most Linux commands/utilities and system administration
+* Familiarity with scripting languages
+* Self-directed and independent ability to prioritize
+* Capable of responding to and resolving alerts of various types
+* Problem solving, troubleshooting and general resourcefulness
+* Be able to demonstrate a level of trust that this role requires
+* Excellent communications skills
+* Commitment to F/OSS communities
+
+
+### How to Apply
+
+If you are interested, please send a note to hiringcommittee@riseup.net  Please explain why you would like to help with Riseup's communication servcies, and include documentation related to your technical experience.
+
+### About Riseup
+
+Riseup employs a small team of passionate, committed and hard-working individuals who care deeply about the organization's mission, and the users we support. Riseup is funded by donations from individuals.
+
+Riseup is committed to a safe workspace and is actively pursuing people from diverse backgrounds. Riseup recognizes and appreciates the contributions of people who identify with groups under-represented or marginalized in our areas of expertise and in our society. We particularly encourage applications from those who are subject to systemic bias, or identify with these groups, including but not limited to women, indigenous people, people with disabilities, visible minorities, recent immigrants, queer and trans people, and residents of the global south.


### PR DESCRIPTION
This is public, but no links to it within the riseup site for now. Mostly this is so we can post it on public job boards that don't host the listing themselves.

If we want to add a link to it later we can.