### PR TITLE
Fix newsletter year table of content

### DIFF
--- a/pages/about-us/newsletter/2004/en.haml
+++ b/pages/about-us/newsletter/2004/en.haml
@@ -1,3 +1,3 @@
 - @title = "2004"
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2005/en.haml
+++ b/pages/about-us/newsletter/2005/en.haml
@@ -1,3 +1,3 @@
 - @title = "2005"
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2006/en.haml
+++ b/pages/about-us/newsletter/2006/en.haml
@@ -1,3 +1,3 @@
 - @title = "2006"
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2007/en.haml
+++ b/pages/about-us/newsletter/2007/en.haml
@@ -1,3 +1,3 @@
 - @title = "2007"
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2008/en.haml
+++ b/pages/about-us/newsletter/2008/en.haml
@@ -1,3 +1,3 @@
 - @title = "2008"
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2009/en.haml
+++ b/pages/about-us/newsletter/2009/en.haml
@@ -1,3 +1,3 @@
 - @title = "2009"
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2010/en.haml
+++ b/pages/about-us/newsletter/2010/en.haml
@@ -1,3 +1,3 @@
 - @title = "2010"
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2011/en.haml
+++ b/pages/about-us/newsletter/2011/en.haml
@@ -1,3 +1,3 @@
 - @title = "2011"
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2012/en.haml
+++ b/pages/about-us/newsletter/2012/en.haml
@@ -1,3 +1,3 @@
 - @title = "2012"
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2013/en.haml
+++ b/pages/about-us/newsletter/2013/en.haml
@@ -1,3 +1,3 @@
 - @title = "2013"
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2014/en.haml
+++ b/pages/about-us/newsletter/2014/en.haml
@@ -1,4 +1,4 @@
 - @title = "2014"
 - @this.translatable = false
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2015/en.haml
+++ b/pages/about-us/newsletter/2015/en.haml
@@ -1,4 +1,4 @@
 - @title = "2015"
 - @this.translatable = false
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2016/en.haml
+++ b/pages/about-us/newsletter/2016/en.haml
@@ -1,4 +1,4 @@
 - @title = "2016"
 - @this.translatable = false
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2017/en.haml
+++ b/pages/about-us/newsletter/2017/en.haml
@@ -1,4 +1,4 @@
 - @title = "2017"
 - @this.translatable = false
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2018/en.haml
+++ b/pages/about-us/newsletter/2018/en.haml
@@ -1,4 +1,4 @@
 - @title = "2018"
 - @this.translatable = false
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2019/en.haml
+++ b/pages/about-us/newsletter/2019/en.haml
@@ -1,4 +1,4 @@
 - @title = "2019"
 - @this.translatable = false
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]

--- a/pages/about-us/newsletter/2020/en.haml
+++ b/pages/about-us/newsletter/2020/en.haml
@@ -1,4 +1,4 @@
 - @title = "2020"
 - @this.translatable = false
 
-= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc, :numeric => true}]
+= child_summaries :include_toc => true, :order_by => [:name, {:direction => :desc}]


### PR DESCRIPTION
With `:numeric => true` in the `:order_by` parameters, instead of displaying the list of newsletters for a given year, only `true` was displayed. Without it, it works as expected.

<details>
<summary>Here's https://riseup.net/en/about-us/newsletter/2010</summary>

![image](https://github.com/riseupnet/riseup_help/assets/427123/68521826-05ac-4e9b-aa62-8d829e9a0cae)
</details>

<details>
<summary>Here's my local version with this PR</summary>

![image](https://github.com/riseupnet/riseup_help/assets/427123/a989fad7-3521-48ca-be78-bf4c2f6aa199)
</details>

Edit : I just discovered [this issue](https://github.com/leapcode/amber/issues/12), and I'm not sure why `:numeric => true` is neccessary here. @taggart you may want to check this since you're the person who open the issue on amber.