### PR TITLE
Add Gemfile to install amber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ public/*
 !public/.gitkeep
 *~
 .sass-cache
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'webrick'
+gem 'amber'


### PR DESCRIPTION
Amber is not package in linux distros, so in this case, I prefer to installed it locally to the project with `bundler` instead of globally on my system using `gem install amber`. So here's the Gemfile necessary to make it works with ruby 3.0.6.

I ignore the `Gemfile.lock` to avoid any conflict on other people system, but if it's better to commit it, I'll commit it.