### PR TITLE
Add anarchyplanet.org to radical servers list

### DIFF
--- a/pages/security/resources/radical-servers/en.text
+++ b/pages/security/resources/radical-servers/en.text
@@ -453,6 +453,15 @@ h2. tao.ca
 * Mailing lists
 * Website hosting
 
+h2. https://anarchyplanet.org/
+
+[[anarchyplanet.org->https://anarchyplanet.org/]] is a constellation of infrastructure projects hosted on servers run by an anarchist collective. They provide low/no-cost hosting and free access to several services.
+
+* Chat
+* Etherpad
+* Jitsi
+* Web/video hosting
+* Custom
 
 h1. In memoriam
 


### PR DESCRIPTION
The Anarchist hosting collective behind https://anarchistnews.org, https://theanarchistlibrary.org, and several other projects should be added to the list.