### PR TITLE
Clean up old and dangerous apt info

### DIFF
--- a/pages/vpn/linux/en.md
+++ b/pages/vpn/linux/en.md
@@ -35,14 +35,7 @@ The VPN is packaged in Debian bookworm and later, install it by running the foll
 
        sudo apt install riseup-vpn
 
-For older releases, run the following:
-
-       sudo apt install leap-archive-keyring
-       echo "deb https://deb.leap.se/client release buster" | sudo tee -a /etc/apt/sources.list.d/leap.list
-       sudo apt update
-       sudo apt install riseup-vpn
-
-Warning: that repository is out of date and unsupported, it will soon be removed, see [issue 693](https://0xacab.org/leap/bitmask-vpn/-/issues/693) for followup.
+Older releases are not currently supported (but you can use the snap method above).
 
 ## Troubleshooting
 

--- a/pages/vpn/linux/fr.md
+++ b/pages/vpn/linux/fr.md
@@ -33,9 +33,6 @@ Si jamais un message d'erreur apparaît indiquant que "python" n'est pas install
 
 Exécutez les commandes suivantes dans un terminal pour installer RiseupVPN avec le paquet pour Debian Stable.
 
-       sudo apt install leap-archive-keyring
-       echo "deb https://deb.leap.se/client release buster" | sudo tee -a /etc/apt/sources.list.d/leap.list
-       sudo apt update
        sudo apt install riseup-vpn
 
 ## Problèmes

--- a/pages/vpn/linux/pt.md
+++ b/pages/vpn/linux/pt.md
@@ -32,9 +32,6 @@ Se você receber um erro dizendo que "python" está faltando em `/usr/bin/env`, 
 
 Execute os seguintes comandos em um terminal para instalar o pacote Debian Stable:
 
-       sudo apt install leap-archive-keyring
-       echo "deb https://deb.leap.se/client release buster" | sudo tee -a /etc/apt/sources.list.d/leap.list
-       sudo apt update
        sudo apt install riseup-vpn
 
 ## Resolução de problemas


### PR DESCRIPTION
anarcat added a warning one year ago. Even if people are still using bullseye, this advice is wrong/dangerous. If a bullseye-backport becomes available we can add that.

Removed from the translations that had it, a couple lack the whole "Package Installation" section entirely, I did not attempt to add it.

It still needs to be removed upstream
https://0xacab.org/leap/bitmask-vpn/-/issues/693