### PR TITLE
Adding lang attributes

### DIFF
--- a/amber/layouts/_sidebar.html.haml
+++ b/amber/layouts/_sidebar.html.haml
@@ -15,7 +15,7 @@
 .sidebar-addendum
   .locale-links
     - available_languages.each do |name, code, url|
-      %a.label{:href => url, :class => (I18n.locale == code ? 'label-primary' : '')}= name
+      %a.label{:href => url, :lang => code, :class => (I18n.locale == code ? 'label-primary' : '')}= name
 
 .sidebar-addendum
   = link(t(:support_riseup) => 'donate', :class => 'btn btn-block btn-default')

--- a/amber/layouts/home.html.haml
+++ b/amber/layouts/home.html.haml
@@ -28,7 +28,7 @@
                 .col-sm-8
                   .locale-links
                     - available_languages.each do |name, code, url|
-                      %a.label{:href => url, :class => (I18n.locale == code ? 'label-primary' : '')}= name
+                      %a.label{:href => url, :lang => code, :class => (I18n.locale == code ? 'label-primary' : '')}= name
                   <br>
                   = render 'common/home_donate'
                   = yield :content


### PR DESCRIPTION
Adding HTML `lang` attributes to (what I think) are all of the instances of non-default page languages on help site. This will ensure that screen readers will render languages other than the page default with the appropriate speech synthesizer.

See additional documentation in the [WCAG Language of Parts documentation](https://www.w3.org/WAI/WCAG22/Understanding/language-of-parts.html).