### PR TITLE
Add Skip Link

### DIFF
--- a/amber/layouts/_skip_link.html.haml
+++ b/amber/layouts/_skip_link.html.haml
@@ -1,0 +1,1 @@
+%a.skip-link(href="#main-content") Skip to Main Content

--- a/amber/layouts/default.html.haml
+++ b/amber/layouts/default.html.haml
@@ -10,7 +10,6 @@
     %link(rel="stylesheet" href="/assets/font-awesome-4.6.3/css/font-awesome.min.css")
     %link(rel="stylesheet" href="/assets/style.css")
     %link(rel="icon" href="/assets/images/favicon.png" type="image/x-icon")
-    = html_head_base
   %body
     = render 'layouts/skip_link'
     = render 'layouts/riseup_bar'

--- a/amber/layouts/default.html.haml
+++ b/amber/layouts/default.html.haml
@@ -12,6 +12,7 @@
     %link(rel="icon" href="/assets/images/favicon.png" type="image/x-icon")
     = html_head_base
   %body
+    = render 'layouts/skip_link'
     = render 'layouts/riseup_bar'
     #masthead
       = render 'layouts/masthead'
@@ -21,7 +22,7 @@
           #sidebar.col-sm-3.col-md-2
             = render 'layouts/sidebar'
           .col-sm-9.col-md-10
-            .shadow-box
+            #main-content.shadow-box(tabindex="-1")
               .title-box
                 = yield :title
                 - if @page.props.summary

--- a/amber/layouts/home.html.haml
+++ b/amber/layouts/home.html.haml
@@ -12,6 +12,7 @@
     %link(rel="icon" href="/assets/images/favicon.png" type="image/x-icon")
     = html_head_base
   %body.home
+    = render 'layouts/skip_link'
     = render 'layouts/riseup_bar'
     #masthead
       = render 'layouts/masthead'
@@ -31,7 +32,8 @@
                       %a.label{:href => url, :lang => code, :class => (I18n.locale == code ? 'label-primary' : '')}= name
                   <br>
                   = render 'common/home_donate'
-                  = yield :content
+                  #main-content(tabindex="-1")
+                    = yield :content
                 .col-sm-4
                   .feed
                     %h2= t(:system_updates)

--- a/amber/layouts/home.html.haml
+++ b/amber/layouts/home.html.haml
@@ -10,7 +10,6 @@
     %link(rel="stylesheet" href="/assets/font-awesome-4.6.3/css/font-awesome.min.css")
     %link(rel="stylesheet" href="/assets/style.css")
     %link(rel="icon" href="/assets/images/favicon.png" type="image/x-icon")
-    = html_head_base
   %body.home
     = render 'layouts/skip_link'
     = render 'layouts/riseup_bar'

--- a/pages/assets/_layout.scss
+++ b/pages/assets/_layout.scss
@@ -3,6 +3,7 @@
 // LAYOUT STRUCTURE
 //
 // %body
+//   .skip-link
 //   #riseup-bar.nav-home
 //     #riseup-nav
 //   #masthead
@@ -51,6 +52,17 @@ body {
 //    flex: 1 1;
 //  }
 //}
+
+//
+// SKIP LINK
+//
+.skip-link {
+  position:absolute;
+  left: -1312px;
+  &:focus {
+    position: initial;
+  }
+}
 
 //
 // MASTHEAD

--- a/pages/assets/_riseup.scss
+++ b/pages/assets/_riseup.scss
@@ -13,7 +13,7 @@
 //  color: white;
 //}
 
-.content-box h1:first-child, .content-box h2:first-child {
+.content-box h2:first-child {
   margin-top: 0px !important;
 }
 


### PR DESCRIPTION
I'm trying to submit a few PRs for accessibility issues I've noticed on the help site & I happened to notice that there's no easy way to skip the site's navigation directly to the main content of the page.

Many users with disabilities may want to interact directly with the main content of a page & find it tedious to navigate through the (sometimes long) navigation on the site. More info can be found on the [WCAG Bypass Blocks SC page](https://www.w3.org/WAI/WCAG22/Understanding/bypass-blocks.html).

I think most of this PR should be fairly uncontroversial, but one thing I wanted to specifically highlight was the `base` element in the `head`. This causes every fragment identifier to reload the page, making a standard skip link behave very strangely. In testing it with amber, I didn't notice any issues after I removed it, but there may be something I missed.