### PR TITLE
Adding programmatic label to search field

### DIFF
--- a/amber/layouts/_sidebar.html.haml
+++ b/amber/layouts/_sidebar.html.haml
@@ -7,7 +7,7 @@
 .sidebar-addendum
   %form#searchform(action="https://duckduckgo.com" name="searchform")
     .input-group
-      %input.form-control(name="q" type="search")
+      %input.form-control(name="q" type="search" aria-label="Search Help")
       %input(name="sites" type="hidden" value="help.riseup.net")
       .span.input-group-btn
         %input.btn.btn-default(value="Search" type="submit")


### PR DESCRIPTION
One more PR... sorry for this flurry of changes.

This just adds a programmatic label to the search input field. This just makes sure screen reader users (primarily) will be able to know definitively that this is the field where they should enter their search query.